### PR TITLE
Manually update jarm specs

### DIFF
--- a/sync/specs/oauth-v2-jarm-05.html
+++ b/sync/specs/oauth-v2-jarm-05.html
@@ -1,0 +1,2052 @@
+<!DOCTYPE html>
+<html lang="en" class="Internet-Draft">
+<head>
+<meta charset="utf-8">
+<meta content="Common,Latin" name="scripts">
+<meta content="initial-scale=1.0" name="viewport">
+<title>JWT Secured Authorization Response Mode for OAuth 2.0 (JARM) - Draft 05 incorporating errata set 1</title>
+<meta content="Torsten Lodderstedt" name="author">
+<meta content="Brian Campbell" name="author">
+<meta content="xml2rfc 3.16.0" name="generator">
+<meta content="security" name="keyword">
+<meta content="oauth2" name="keyword">
+<meta content="oauth-v2-jarm-05" name="ietf.draft">
+<!-- Generator version information:
+  xml2rfc 3.16.0
+    Python 3.10.2
+    appdirs 1.4.4
+    ConfigArgParse 1.5.3
+    google-i18n-address 2.5.2
+    html5lib 1.1
+    intervaltree 3.1.0
+    Jinja2 3.1.2
+    lxml 4.9.2
+    MarkupSafe 2.1.2
+    pycountry 22.3.5
+    PyYAML 6.0
+    requests 2.28.2
+    setuptools 57.5.0
+    six 1.16.0
+    wcwidth 0.2.6
+-->
+<link href="./oauth-v2-jarm-05.xml" rel="alternate" type="application/rfc+xml">
+<link href="#copyright" rel="license">
+<style type="text/css">/*
+
+  NOTE: Changes at the bottom of this file overrides some earlier settings.
+
+  Once the style has stabilized and has been adopted as an official RFC style,
+  this can be consolidated so that style settings occur only in one place, but
+  for now the contents of this file consists first of the initial CSS work as
+  provided to the RFC Formatter (xml2rfc) work, followed by itemized and
+  commented changes found necessary during the development of the v3
+  formatters.
+
+*/
+
+/* fonts */
+@import url('https://fonts.googleapis.com/css?family=Noto+Sans'); /* Sans-serif */
+@import url('https://fonts.googleapis.com/css?family=Noto+Serif'); /* Serif (print) */
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono'); /* Monospace */
+
+:root {
+  --font-sans: 'Noto Sans', Arial, Helvetica, sans-serif;
+  --font-serif: 'Noto Serif', 'Times', 'Times New Roman', serif;
+  --font-mono: 'Roboto Mono', Courier, 'Courier New', monospace;
+}
+
+@viewport {
+  zoom: 1.0;
+  width: extend-to-zoom;
+}
+@-ms-viewport {
+  width: extend-to-zoom;
+  zoom: 1.0;
+}
+/* general and mobile first */
+html {
+}
+body {
+  max-width: 90%;
+  margin: 1.5em auto;
+  color: #222;
+  background-color: #fff;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  scroll-behavior: smooth;
+}
+.ears {
+  display: none;
+}
+
+/* headings */
+#title, h1, h2, h3, h4, h5, h6 {
+  margin: 1em 0 0.5em;
+  font-weight: bold;
+  line-height: 1.3;
+}
+#title {
+  clear: both;
+  border-bottom: 1px solid #ddd;
+  margin: 0 0 0.5em 0;
+  padding: 1em 0 0.5em;
+}
+.author {
+  padding-bottom: 4px;
+}
+h1 {
+  font-size: 26px;
+  margin: 1em 0;
+}
+h2 {
+  font-size: 22px;
+  margin-top: -20px;  /* provide offset for in-page anchors */
+  padding-top: 33px;
+}
+h3 {
+  font-size: 18px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h4 {
+  font-size: 16px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h5, h6 {
+  font-size: 14px;
+}
+#n-copyright-notice {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+}
+/* general structure */
+p {
+  padding: 0;
+  margin: 0 0 1em 0;
+  text-align: left;
+}
+div, span {
+  position: relative;
+}
+div {
+  margin: 0;
+}
+.alignRight.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignRight.art-text pre {
+  padding: 0;
+}
+.alignRight {
+  margin: 1em 0;
+}
+.alignRight > *:first-child {
+  border: none;
+  margin: 0;
+  float: right;
+  clear: both;
+}
+.alignRight > *:nth-child(2) {
+  clear: both;
+  display: block;
+  border: none;
+}
+svg {
+  display: block;
+}
+svg[font-family~="serif" i], svg [font-family~="serif" i] {
+  font-family: var(--font-serif);
+}
+svg[font-family~="sans-serif" i], svg [font-family~="sans-serif" i] {
+  font-family: var(--font-sans);
+}
+svg[font-family~="monospace" i], svg [font-family~="monospace" i] {
+  font-family: var(--font-mono);
+}
+.alignCenter.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignCenter.art-text pre {
+  padding: 0;
+}
+.alignCenter {
+  margin: 1em 0;
+}
+.alignCenter > *:first-child {
+  display: table;
+  border: none;
+  margin: 0 auto;
+}
+
+/* lists */
+ol, ul {
+  padding: 0;
+  margin: 0 0 1em 2em;
+}
+ol ol, ul ul, ol ul, ul ol {
+  margin-left: 1em;
+}
+li {
+  margin: 0 0 0.25em 0;
+}
+.ulCompact li {
+  margin: 0;
+}
+ul.empty, .ulEmpty {
+  list-style-type: none;
+}
+ul.empty li, .ulEmpty li {
+  margin-top: 0.5em;
+}
+ul.ulBare, li.ulBare {
+  margin-left: 0em !important;
+}
+ul.compact, .ulCompact,
+ol.compact, .olCompact {
+  line-height: 100%;
+  margin: 0 0 0 2em;
+}
+
+/* definition lists */
+dl {
+}
+dl > dt {
+  float: left;
+  margin-right: 1em;
+}
+/* 
+dl.nohang > dt {
+  float: none;
+}
+*/
+dl > dd {
+  margin-bottom: .8em;
+  min-height: 1.3em;
+}
+dl.compact > dd, .dlCompact > dd {
+  margin-bottom: 0em;
+}
+dl > dd > dl {
+  margin-top: 0.5em;
+  margin-bottom: 0em;
+}
+
+/* links */
+a {
+  text-decoration: none;
+}
+a[href] {
+  color: #22e; /* Arlen: WCAG 2019 */
+}
+a[href]:hover {
+  background-color: #f2f2f2;
+}
+figcaption a[href],
+a[href].selfRef {
+  color: #222;
+}
+/* XXX probably not this:
+a.selfRef:hover {
+  background-color: transparent;
+  cursor: default;
+} */
+
+/* Figures */
+tt, code, pre {
+  background-color: #f9f9f9;
+  font-family: var(--font-mono);
+}
+pre {
+  border: 1px solid #eee;
+  margin: 0;
+  padding: 1em;
+}
+img {
+  max-width: 100%;
+}
+figure {
+  margin: 0;
+}
+figure blockquote {
+  margin: 0.8em 0.4em 0.4em;
+}
+figcaption {
+  font-style: italic;
+  margin: 0 0 1em 0;
+}
+@media screen {
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
+    max-width: calc(100% - 22px);
+  }
+}
+
+/* aside, blockquote */
+aside, blockquote {
+  margin-left: 0;
+  padding: 1.2em 2em;
+}
+blockquote {
+  background-color: #f9f9f9;
+  color: #111; /* Arlen: WCAG 2019 */
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  margin: 1em 0;
+}
+cite {
+  display: block;
+  text-align: right;
+  font-style: italic;
+}
+
+/* tables */
+table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+}
+th, td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.5em 0.75em;
+}
+th {
+  text-align: left;
+  background-color: #e9e9e9;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f5f5f5;
+}
+table caption {
+  font-style: italic;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+table p {
+  /* XXX to avoid bottom margin on table row signifiers. If paragraphs should
+     be allowed within tables more generally, it would be far better to select on a class. */
+  margin: 0;
+}
+
+/* pilcrow */
+a.pilcrow {
+  color: #666; /* Arlen: AHDJ 2019 */
+  text-decoration: none;
+  visibility: hidden;
+  user-select: none;
+  -ms-user-select: none;
+  -o-user-select:none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+@media screen {
+  aside:hover > a.pilcrow,
+  p:hover > a.pilcrow,
+  blockquote:hover > a.pilcrow,
+  div:hover > a.pilcrow,
+  li:hover > a.pilcrow,
+  pre:hover > a.pilcrow {
+    visibility: visible;
+  }
+  a.pilcrow:hover {
+    background-color: transparent;
+  }
+}
+
+/* misc */
+hr {
+  border: 0;
+  border-top: 1px solid #eee;
+}
+.bcp14 {
+  font-variant: small-caps;
+}
+
+.role {
+  font-variant: all-small-caps;
+}
+
+/* info block */
+#identifiers {
+  margin: 0;
+  font-size: 0.9em;
+}
+#identifiers dt {
+  width: 3em;
+  clear: left;
+}
+#identifiers dd {
+  float: left;
+  margin-bottom: 0;
+}
+/* Fix PDF info block run off issue */
+@media print {
+  #identifiers dd {
+    float: none;
+  }
+}
+#identifiers .authors .author {
+  display: inline-block;
+  margin-right: 1.5em;
+}
+#identifiers .authors .org {
+  font-style: italic;
+}
+
+/* The prepared/rendered info at the very bottom of the page */
+.docInfo {
+  color: #666; /* Arlen: WCAG 2019 */
+  font-size: 0.9em;
+  font-style: italic;
+  margin-top: 2em;
+}
+.docInfo .prepared {
+  float: left;
+}
+.docInfo .prepared {
+  float: right;
+}
+
+/* table of contents */
+#toc  {
+  padding: 0.75em 0 2em 0;
+  margin-bottom: 1em;
+}
+nav.toc ul {
+  margin: 0 0.5em 0 0;
+  padding: 0;
+  list-style: none;
+}
+nav.toc li {
+  line-height: 1.3em;
+  margin: 0.75em 0;
+  padding-left: 1.2em;
+  text-indent: -1.2em;
+}
+/* references */
+.references dt {
+  text-align: right;
+  font-weight: bold;
+  min-width: 7em;
+}
+.references dd {
+  margin-left: 8em;
+  overflow: auto;
+}
+
+.refInstance {
+  margin-bottom: 1.25em;
+}
+
+.references .ascii {
+  margin-bottom: 0.25em;
+}
+
+/* index */
+.index ul {
+  margin: 0 0 0 1em;
+  padding: 0;
+  list-style: none;
+}
+.index ul ul {
+  margin: 0;
+}
+.index li {
+  margin: 0;
+  text-indent: -2em;
+  padding-left: 2em;
+  padding-bottom: 5px;
+}
+.indexIndex {
+  margin: 0.5em 0 1em;
+}
+.index a {
+  font-weight: 700;
+}
+/* make the index two-column on all but the smallest screens */
+@media (min-width: 600px) {
+  .index ul {
+    -moz-column-count: 2;
+    -moz-column-gap: 20px;
+  }
+  .index ul ul {
+    -moz-column-count: 1;
+    -moz-column-gap: 0;
+  }
+}
+
+/* authors */
+address.vcard {
+  font-style: normal;
+  margin: 1em 0;
+}
+
+address.vcard .nameRole {
+  font-weight: 700;
+  margin-left: 0;
+}
+address.vcard .label {
+  font-family: var(--font-sans);
+  margin: 0.5em 0;
+}
+address.vcard .type {
+  display: none;
+}
+.alternative-contact {
+  margin: 1.5em 0 1em;
+}
+hr.addr {
+  border-top: 1px dashed;
+  margin: 0;
+  color: #ddd;
+  max-width: calc(100% - 16px);
+}
+
+/* temporary notes */
+.rfcEditorRemove::before {
+  position: absolute;
+  top: 0.2em;
+  right: 0.2em;
+  padding: 0.2em;
+  content: "The RFC Editor will remove this note";
+  color: #9e2a00; /* Arlen: WCAG 2019 */
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+}
+.rfcEditorRemove {
+  position: relative;
+  padding-top: 1.8em;
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  border-radius: 3px;
+}
+.cref {
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  padding: 2px 4px;
+}
+.crefSource {
+  font-style: italic;
+}
+/* alternative layout for smaller screens */
+@media screen and (max-width: 1023px) {
+  body {
+    padding-top: 2em;
+  }
+  #title {
+    padding: 1em 0;
+  }
+  h1 {
+    font-size: 24px;
+  }
+  h2 {
+    font-size: 20px;
+    margin-top: -18px;  /* provide offset for in-page anchors */
+    padding-top: 38px;
+  }
+  #identifiers dd {
+    max-width: 60%;
+  }
+  #toc {
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    padding: 0;
+    margin: 0;
+    background-color: inherit;
+    border-bottom: 1px solid #ccc;
+  }
+  #toc h2 {
+    margin: -1px 0 0 0;
+    padding: 4px 0 4px 6px;
+    padding-right: 1em;
+    min-width: 190px;
+    font-size: 1.1em;
+    text-align: right;
+    background-color: #444;
+    color: white;
+    cursor: pointer;
+  }
+  #toc h2::before { /* css hamburger */
+    float: right;
+    position: relative;
+    width: 1em;
+    height: 1px;
+    left: -164px;
+    margin: 6px 0 0 0;
+    background: white none repeat scroll 0 0;
+    box-shadow: 0 4px 0 0 white, 0 8px 0 0 white;
+    content: "";
+  }
+  #toc nav {
+    display: none;
+    padding: 0.5em 1em 1em;
+    overflow: auto;
+    height: calc(100vh - 48px);
+    border-left: 1px solid #ddd;
+  }
+}
+
+/* alternative layout for wide screens */
+@media screen and (min-width: 1024px) {
+  body {
+    max-width: 724px;
+    margin: 42px auto;
+    padding-left: 1.5em;
+    padding-right: 29em;
+  }
+  #toc {
+    position: fixed;
+    top: 42px;
+    right: 42px;
+    width: 25%;
+    margin: 0;
+    padding: 0 1em;
+    z-index: 1;
+  }
+  #toc h2 {
+    border-top: none;
+    border-bottom: 1px solid #ddd;
+    font-size: 1em;
+    font-weight: normal;
+    margin: 0;
+    padding: 0.25em 1em 1em 0;
+  }
+  #toc nav {
+    display: block;
+    height: calc(90vh - 84px);
+    bottom: 0;
+    padding: 0.5em 0 0;
+    overflow: auto;
+  }
+  img { /* future proofing */
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+/* pagination */
+@media print {
+  body {
+
+    width: 100%;
+  }
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+  #n-copyright-notice {
+    border-bottom: none;
+  }
+  #toc, #n-introduction {
+    page-break-before: always;
+  }
+  #toc {
+    border-top: none;
+    padding-top: 0;
+  }
+  figure, pre {
+    page-break-inside: avoid;
+  }
+  figure {
+    overflow: scroll;
+  }
+  .breakable pre {
+    break-inside: auto;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+  h2+*, h3+*, h4+*, h5+*, h6+* {
+    page-break-before: avoid;
+  }
+  pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-size: 10pt;
+  }
+  table {
+    border: 1px solid #ddd;
+  }
+  td {
+    border-top: 1px solid #ddd;
+  }
+}
+
+/* This is commented out here, as the string-set: doesn't
+   pass W3C validation currently */
+/*
+.ears thead .left {
+  string-set: ears-top-left content();
+}
+
+.ears thead .center {
+  string-set: ears-top-center content();
+}
+
+.ears thead .right {
+  string-set: ears-top-right content();
+}
+
+.ears tfoot .left {
+  string-set: ears-bottom-left content();
+}
+
+.ears tfoot .center {
+  string-set: ears-bottom-center content();
+}
+
+.ears tfoot .right {
+  string-set: ears-bottom-right content();
+}
+*/
+
+@page :first {
+  padding-top: 0;
+  @top-left {
+    content: normal;
+    border: none;
+  }
+  @top-center {
+    content: normal;
+    border: none;
+  }
+  @top-right {
+    content: normal;
+    border: none;
+  }
+}
+
+@page {
+  size: A4;
+  margin-bottom: 45mm;
+  padding-top: 20px;
+  /* The following is commented out here, but set appropriately by in code, as
+     the content depends on the document */
+  /*
+  @top-left {
+    content: 'Internet-Draft';
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-left {
+    content: string(ears-top-left);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-center {
+    content: string(ears-top-center);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-right {
+    content: string(ears-top-right);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @bottom-left {
+    content: string(ears-bottom-left);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-center {
+    content: string(ears-bottom-center);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-right {
+      content: '[Page ' counter(page) ']';
+      vertical-align: top;
+      border-top: solid 1px #ccc;
+  }
+  */
+
+}
+
+/* Changes introduced to fix issues found during implementation */
+/* Make sure links are clickable even if overlapped by following H* */
+a {
+  z-index: 2;
+}
+/* Separate body from document info even without intervening H1 */
+section {
+  clear: both;
+}
+
+
+/* Top align author divs, to avoid names without organization dropping level with org names */
+.author {
+  vertical-align: top;
+}
+
+/* Leave room in document info to show Internet-Draft on one line */
+#identifiers dt {
+  width: 8em;
+}
+
+/* Don't waste quite as much whitespace between label and value in doc info */
+#identifiers dd {
+  margin-left: 1em;
+}
+
+/* Give floating toc a background color (needed when it's a div inside section */
+#toc {
+  background-color: white;
+}
+
+/* Make the collapsed ToC header render white on gray also when it's a link */
+@media screen and (max-width: 1023px) {
+  #toc h2 a,
+  #toc h2 a:link,
+  #toc h2 a:focus,
+  #toc h2 a:hover,
+  #toc a.toplink,
+  #toc a.toplink:hover {
+    color: white;
+    background-color: #444;
+    text-decoration: none;
+  }
+}
+
+/* Give the bottom of the ToC some whitespace */
+@media screen and (min-width: 1024px) {
+  #toc {
+    padding: 0 0 1em 1em;
+  }
+}
+
+/* Style section numbers with more space between number and title */
+.section-number {
+  padding-right: 0.5em;
+}
+
+/* prevent monospace from becoming overly large */
+tt, code, pre {
+  font-size: 95%;
+}
+
+/* Fix the height/width aspect for ascii art*/
+.sourcecode pre,
+.art-text pre {
+  line-height: 1.12;
+}
+
+
+/* Add styling for a link in the ToC that points to the top of the document */
+a.toplink {
+  float: right;
+  margin-right: 0.5em;
+}
+
+/* Fix the dl styling to match the RFC 7992 attributes */
+dl > dt,
+dl.dlParallel > dt {
+  float: left;
+  margin-right: 1em;
+}
+dl.dlNewline > dt {
+  float: none;
+}
+
+/* Provide styling for table cell text alignment */
+table td.text-left,
+table th.text-left {
+  text-align: left;
+}
+table td.text-center,
+table th.text-center {
+  text-align: center;
+}
+table td.text-right,
+table th.text-right {
+  text-align: right;
+}
+
+/* Make the alternative author contact information look less like just another
+   author, and group it closer with the primary author contact information */
+.alternative-contact {
+  margin: 0.5em 0 0.25em 0;
+}
+address .non-ascii {
+  margin: 0 0 0 2em;
+}
+
+/* With it being possible to set tables with alignment
+  left, center, and right, { width: 100%; } does not make sense */
+table {
+  width: auto;
+}
+
+/* Avoid reference text that sits in a block with very wide left margin,
+   because of a long floating dt label.*/
+.references dd {
+  overflow: visible;
+}
+
+/* Control caption placement */
+caption {
+  caption-side: bottom;
+}
+
+/* Limit the width of the author address vcard, so names in right-to-left
+   script don't end up on the other side of the page. */
+
+address.vcard {
+  max-width: 30em;
+  margin-right: auto;
+}
+
+/* For address alignment dependent on LTR or RTL scripts */
+address div.left {
+  text-align: left;
+}
+address div.right {
+  text-align: right;
+}
+
+/* Provide table alignment support.  We can't use the alignX classes above
+   since they do unwanted things with caption and other styling. */
+table.right {
+ margin-left: auto;
+ margin-right: 0;
+}
+table.center {
+ margin-left: auto;
+ margin-right: auto;
+}
+table.left {
+ margin-left: 0;
+ margin-right: auto;
+}
+
+/* Give the table caption label the same styling as the figcaption */
+caption a[href] {
+  color: #222;
+}
+
+@media print {
+  .toplink {
+    display: none;
+  }
+
+  /* avoid overwriting the top border line with the ToC header */
+  #toc {
+    padding-top: 1px;
+  }
+
+  /* Avoid page breaks inside dl and author address entries */
+  .vcard {
+    page-break-inside: avoid;
+  }
+
+}
+/* Tweak the bcp14 keyword presentation */
+.bcp14 {
+  font-variant: small-caps;
+  font-weight: bold;
+  font-size: 0.9em;
+}
+/* Tweak the invisible space above H* in order not to overlay links in text above */
+ h2 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 31px;
+ }
+ h3 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+ h4 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+/* Float artwork pilcrow to the right */
+@media screen {
+  .artwork a.pilcrow {
+    display: block;
+    line-height: 0.7;
+    margin-top: 0.15em;
+  }
+}
+/* Make pilcrows on dd visible */
+@media screen {
+  dd:hover > a.pilcrow {
+    visibility: visible;
+  }
+}
+/* Make the placement of figcaption match that of a table's caption
+   by removing the figure's added bottom margin */
+.alignLeft.art-text,
+.alignCenter.art-text,
+.alignRight.art-text {
+   margin-bottom: 0;
+}
+.alignLeft,
+.alignCenter,
+.alignRight {
+  margin: 1em 0 0 0;
+}
+/* In print, the pilcrow won't show on hover, so prevent it from taking up space,
+   possibly even requiring a new line */
+@media print {
+  a.pilcrow {
+    display: none;
+  }
+}
+/* Styling for the external metadata */
+div#external-metadata {
+  background-color: #eee;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  display: none;
+}
+div#internal-metadata {
+  padding: 0.5em;                       /* to match the external-metadata padding */
+}
+/* Styling for title RFC Number */
+h1#rfcnum {
+  clear: both;
+  margin: 0 0 -1em;
+  padding: 1em 0 0 0;
+}
+/* Make .olPercent look the same as <ol><li> */
+dl.olPercent > dd {
+  margin-bottom: 0.25em;
+  min-height: initial;
+}
+/* Give aside some styling to set it apart */
+aside {
+  border-left: 1px solid #ddd;
+  margin: 1em 0 1em 2em;
+  padding: 0.2em 2em;
+}
+aside > dl,
+aside > ol,
+aside > ul,
+aside > table,
+aside > p {
+  margin-bottom: 0.5em;
+}
+/* Additional page break settings */
+@media print {
+  figcaption, table caption {
+    page-break-before: avoid;
+  }
+}
+/* Font size adjustments for print */
+@media print {
+  body  { font-size: 10pt;      line-height: normal; max-width: 96%; }
+  h1    { font-size: 1.72em;    padding-top: 1.5em; } /* 1*1.2*1.2*1.2 */
+  h2    { font-size: 1.44em;    padding-top: 1.5em; } /* 1*1.2*1.2 */
+  h3    { font-size: 1.2em;     padding-top: 1.5em; } /* 1*1.2 */
+  h4    { font-size: 1em;       padding-top: 1.5em; }
+  h5, h6 { font-size: 1em;      margin: initial; padding: 0.5em 0 0.3em; }
+}
+/* Sourcecode margin in print, when there's no pilcrow */
+@media print {
+  .artwork,
+  .artwork > pre,
+  .sourcecode {
+    margin-bottom: 1em;
+  }
+}
+/* Avoid narrow tables forcing too narrow table captions, which may render badly */
+table {
+  min-width: 20em;
+}
+/* ol type a */
+ol.type-a { list-style-type: lower-alpha; }
+ol.type-A { list-style-type: upper-alpha; }
+ol.type-i { list-style-type: lower-roman; }
+ol.type-I { list-style-type: lower-roman; }
+/* Apply the print table and row borders in general, on request from the RPC,
+and increase the contrast between border and odd row background slightly */
+table {
+  border: 1px solid #ddd;
+}
+td {
+  border-top: 1px solid #ddd;
+}
+tr {
+  break-inside: avoid;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f8f8f8;
+}
+/* Use style rules to govern display of the TOC. */
+@media screen and (max-width: 1023px) {
+  #toc nav { display: none; }
+  #toc.active nav { display: block; }
+}
+/* Add support for keepWithNext */
+.keepWithNext {
+  break-after: avoid-page;
+  break-after: avoid-page;
+}
+/* Add support for keepWithPrevious */
+.keepWithPrevious {
+  break-before: avoid-page;
+}
+/* Change the approach to avoiding breaks inside artwork etc. */
+figure, pre, table, .artwork, .sourcecode  {
+  break-before: auto;
+  break-after: auto;
+}
+/* Avoid breaks between <dt> and <dd> */
+dl {
+  break-before: auto;
+  break-inside: auto;
+}
+dt {
+  break-before: auto;
+  break-after: avoid-page;
+}
+dd {
+  break-before: avoid-page;
+  break-after: auto;
+  orphans: 3;
+  widows: 3
+}
+span.break, dd.break {
+  margin-bottom: 0;
+  min-height: 0;
+  break-before: auto;
+  break-inside: auto;
+  break-after: auto;
+}
+/* Undo break-before ToC */
+@media print {
+  #toc {
+    break-before: auto;
+  }
+}
+/* Text in compact lists should not get extra bottom margin space,
+   since that would makes the list not compact */
+ul.compact p, .ulCompact p,
+ol.compact p, .olCompact p {
+ margin: 0;
+}
+/* But the list as a whole needs the extra space at the end */
+section ul.compact,
+section .ulCompact,
+section ol.compact,
+section .olCompact {
+  margin-bottom: 1em;                    /* same as p not within ul.compact etc. */
+}
+/* The tt and code background above interferes with for instance table cell
+   backgrounds.  Changed to something a bit more selective. */
+tt, code {
+  background-color: transparent;
+}
+p tt, p code, li tt, li code {
+  background-color: #f8f8f8;
+}
+/* Tweak the pre margin -- 0px doesn't come out well */
+pre {
+   margin-top: 0.5px;
+}
+/* Tweak the compact list text */
+ul.compact, .ulCompact,
+ol.compact, .olCompact,
+dl.compact, .dlCompact {
+  line-height: normal;
+}
+/* Don't add top margin for nested lists */
+li > ul, li > ol, li > dl,
+dd > ul, dd > ol, dd > dl,
+dl > dd > dl {
+  margin-top: initial;
+}
+/* Elements that should not be rendered on the same line as a <dt> */
+/* This should match the element list in writer.text.TextWriter.render_dl() */
+dd > div.artwork:first-child,
+dd > aside:first-child,
+dd > figure:first-child,
+dd > ol:first-child,
+dd > div.sourcecode:first-child,
+dd > table:first-child,
+dd > ul:first-child {
+  clear: left;
+}
+/* fix for weird browser behaviour when <dd/> is empty */
+dt+dd:empty::before{
+  content: "\00a0";
+}
+/* Make paragraph spacing inside <li> smaller than in body text, to fit better within the list */
+li > p {
+  margin-bottom: 0.5em
+}
+/* Don't let p margin spill out from inside list items */
+li > p:last-of-type:only-child {
+  margin-bottom: 0;
+}
+</style>
+<link href="rfc-local.css" rel="stylesheet" type="text/css">
+</head>
+<body class="xml2rfc">
+<script src="metadata.min.js"></script>
+<table class="ears">
+<thead><tr>
+<td class="left"></td>
+<td class="center">OAuth JARM</td>
+<td class="right">May 2025</td>
+</tr></thead>
+<tfoot><tr>
+<td class="left">Lodderstedt &amp; Campbell</td>
+<td class="center">Standards Track</td>
+<td class="right">[Page]</td>
+</tr></tfoot>
+</table>
+<div id="external-metadata" class="document-information"></div>
+<div id="internal-metadata" class="document-information">
+<dl id="identifiers">
+<dt class="label-workgroup">Workgroup:</dt>
+<dd class="workgroup">FAPI</dd>
+<dt class="label-published">Published:</dt>
+<dd class="published">
+<time datetime="2025-05-28" class="published">28 May 2025</time>
+    </dd>
+<dt class="label-authors">Authors:</dt>
+<dd class="authors">
+<div class="author">
+      <div class="author-name">T. Lodderstedt</div>
+<div class="org">SPRIND</div>
+</div>
+<div class="author">
+      <div class="author-name">B. Campbell</div>
+<div class="org">Ping Identity</div>
+</div>
+</dd>
+</dl>
+</div>
+<h1 id="title">JWT Secured Authorization Response Mode for OAuth 2.0 (JARM) - Draft 05 incorporating errata set 1</h1>
+<div id="toc">
+<section id="section-toc.1">
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
+        </h2>
+<nav class="toc"><ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1">
+            <p id="section-toc.1-1.1.1"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-introduction" class="internal xref">Introduction</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.1">
+                <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="auto internal xref">1.1</a>.  <a href="#name-notational-conventions" class="internal xref">Notational Conventions</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.2">
+                <p id="section-toc.1-1.1.2.2.1" class="keepWithNext"><a href="#section-1.2" class="auto internal xref">1.2</a>.  <a href="#name-terms-and-definitions" class="internal xref">Terms and definitions</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.3">
+                <p id="section-toc.1-1.1.2.3.1" class="keepWithNext"><a href="#section-1.3" class="auto internal xref">1.3</a>.  <a href="#name-symbols-and-abbreviated-ter" class="internal xref">Symbols and Abbreviated terms</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
+            <p id="section-toc.1-1.2.1"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-jwt-based-response-mode" class="internal xref">JWT-based Response Mode</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.1">
+                <p id="section-toc.1-1.2.2.1.1"><a href="#section-2.1" class="auto internal xref">2.1</a>.  <a href="#name-the-jwt-response-document" class="internal xref">The JWT Response Document</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.1.2.1">
+                    <p id="section-toc.1-1.2.2.1.2.1.1"><a href="#section-2.1.1" class="auto internal xref">2.1.1</a>.  <a href="#name-example-response-type-code" class="internal xref">Example Response Type "code"</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.2">
+                <p id="section-toc.1-1.2.2.2.1"><a href="#section-2.2" class="auto internal xref">2.2</a>.  <a href="#name-signing-and-encryption" class="internal xref">Signing and Encryption</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.3">
+                <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="auto internal xref">2.3</a>.  <a href="#name-response-encoding" class="internal xref">Response Encoding</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.3.2.1">
+                    <p id="section-toc.1-1.2.2.3.2.1.1"><a href="#section-2.3.1" class="auto internal xref">2.3.1</a>.  <a href="#name-response-mode-queryjwt" class="internal xref">Response Mode "query.jwt"</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.3.2.2">
+                    <p id="section-toc.1-1.2.2.3.2.2.1"><a href="#section-2.3.2" class="auto internal xref">2.3.2</a>.  <a href="#name-response-mode-fragmentjwt" class="internal xref">Response Mode "fragment.jwt"</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.3.2.3">
+                    <p id="section-toc.1-1.2.2.3.2.3.1"><a href="#section-2.3.3" class="auto internal xref">2.3.3</a>.  <a href="#name-response-mode-form_postjwt" class="internal xref">Response Mode "form_post.jwt"</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.3.2.4">
+                    <p id="section-toc.1-1.2.2.3.2.4.1"><a href="#section-2.3.4" class="auto internal xref">2.3.4</a>.  <a href="#name-response-mode-jwt" class="internal xref">Response Mode "jwt"</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.4">
+                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="auto internal xref">2.4</a>.  <a href="#name-processing-rules" class="internal xref">Processing rules</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-client-metadata" class="internal xref">Client Metadata</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-authorization-server-metada" class="internal xref">Authorization Server Metadata</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.1">
+                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="auto internal xref">5.1</a>.  <a href="#name-dos-using-specially-crafted" class="internal xref">DoS using specially crafted JWTs</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.2">
+                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="auto internal xref">5.2</a>.  <a href="#name-protocol-run-integrity" class="internal xref">Protocol Run Integrity</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3">
+                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="auto internal xref">5.3</a>.  <a href="#name-mix-up" class="internal xref">Mix-Up</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.4">
+                <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="auto internal xref">5.4</a>.  <a href="#name-code-leakage" class="internal xref">Code Leakage</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-privacy-considerations" class="internal xref">Privacy Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.1">
+                <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="auto internal xref">7.1</a>.  <a href="#name-oauth-dynamic-client-regist" class="internal xref">OAuth Dynamic Client Registration Metadata Registration</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.1.2.1">
+                    <p id="section-toc.1-1.7.2.1.2.1.1"><a href="#section-7.1.1" class="auto internal xref">7.1.1</a>.  <a href="#name-registry-contents" class="internal xref">Registry Contents</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.2">
+                <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="auto internal xref">7.2</a>.  <a href="#name-oauth-authorization-server-" class="internal xref">OAuth Authorization Server Metadata Registration</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.2.2.1">
+                    <p id="section-toc.1-1.7.2.2.2.1.1"><a href="#section-7.2.1" class="auto internal xref">7.2.1</a>.  <a href="#name-registry-contents-2" class="internal xref">Registry Contents</a></p>
+</li>
+                </ul>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-acknowledgements" class="internal xref">Acknowledgements</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#appendix-B" class="auto internal xref">Appendix B</a>.  <a href="#name-notices" class="internal xref">Notices</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
+            <p id="section-toc.1-1.12.1"><a href="#appendix-C" class="auto internal xref">Appendix C</a>.  <a href="#name-document-history" class="internal xref">Document History</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
+            <p id="section-toc.1-1.13.1"><a href="#appendix-D" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
+</li>
+        </ul>
+</nav>
+</section>
+</div>
+<div id="introduction">
+<section id="section-1">
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
+      </h2>
+<p id="section-1-1">This document defines a new JWT-based mode to encode OAuth authorization responses. Clients are enabled to request
+the transmission of the authorization response parameters along with additional data in JWT format.
+This mechanism enhances the security of the standard authorization response with support for signing and optional encryption of the response.
+A signed response provides message integrity, sender authentication, audience restriction, and protection from mix-up attacks. Encrypting the response provides confidentiality of the response parameter values.
+The JWT authorization response mode can be used in conjunction with any response type.<a href="#section-1-1" class="pilcrow">¶</a></p>
+<div id="notational-conventions">
+<section id="section-1.1">
+        <h3 id="name-notational-conventions">
+<a href="#section-1.1" class="section-number selfRef">1.1. </a><a href="#name-notational-conventions" class="section-name selfRef">Notational Conventions</a>
+        </h3>
+<p id="section-1.1-1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
+NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED",
+"MAY", and "OPTIONAL" in this document are to be interpreted as
+described in BCP 14 <span>[<a href="#RFC2119" class="cite xref">RFC2119</a>]</span> <span>[<a href="#RFC8174" class="cite xref">RFC8174</a>]</span> when, and only when, they
+appear in all capitals, as shown here.<a href="#section-1.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="terms-and-definitions">
+<section id="section-1.2">
+        <h3 id="name-terms-and-definitions">
+<a href="#section-1.2" class="section-number selfRef">1.2. </a><a href="#name-terms-and-definitions" class="section-name selfRef">Terms and definitions</a>
+        </h3>
+<p id="section-1.2-1">For the purpose of this document, the terms defined in <span>[<a href="#RFC6749" class="cite xref">RFC6749</a>]</span> and <span>[<a href="#OIDC" class="cite xref">OIDC</a>]</span> apply.<a href="#section-1.2-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="symbols-and-abbreviated-terms">
+<section id="section-1.3">
+        <h3 id="name-symbols-and-abbreviated-ter">
+<a href="#section-1.3" class="section-number selfRef">1.3. </a><a href="#name-symbols-and-abbreviated-ter" class="section-name selfRef">Symbols and Abbreviated terms</a>
+        </h3>
+<p id="section-1.3-1"><strong>API</strong> – Application Programming Interface<a href="#section-1.3-1" class="pilcrow">¶</a></p>
+<p id="section-1.3-2"><strong>CSRF</strong> - Cross Site Request Forgery<a href="#section-1.3-2" class="pilcrow">¶</a></p>
+<p id="section-1.3-3"><strong>HTTP</strong> – Hyper Text Transfer Protocol<a href="#section-1.3-3" class="pilcrow">¶</a></p>
+<p id="section-1.3-4"><strong>OIDF</strong> - OpenID Foundation<a href="#section-1.3-4" class="pilcrow">¶</a></p>
+<p id="section-1.3-5"><strong>TLS</strong> – Transport Layer Security<a href="#section-1.3-5" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="jwt-based-response-mode">
+<section id="section-2">
+      <h2 id="name-jwt-based-response-mode">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-jwt-based-response-mode" class="section-name selfRef">JWT-based Response Mode</a>
+      </h2>
+<p id="section-2-1">This document defines a new JWT-based <span>[<a href="#RFC7519" class="cite xref">RFC7519</a>]</span> mode to encode OAuth <span>[<a href="#RFC6749" class="cite xref">RFC6749</a>]</span> authorization response parameters. All response parameters defined for a given response type are conveyed in a JWT along with additional claims used to further protect the transmission. Since there are different techniques to encode the JWT itself in the response to the client, namely query URI parameter, fragment component and form post, this document defines a set of response mode values in accordance with <span>[<a href="#OIDM" class="cite xref">OIDM</a>]</span> corresponding to these techniques.<a href="#section-2-1" class="pilcrow">¶</a></p>
+<div id="jwt-response">
+<section id="section-2.1">
+        <h3 id="name-the-jwt-response-document">
+<a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-the-jwt-response-document" class="section-name selfRef">The JWT Response Document</a>
+        </h3>
+<p id="section-2.1-1">The JWT always contains the following data utilized to secure the transmission:<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-2.1-2.1">
+            <code>iss</code> - the issuer URL of the authorization server that created the response<a href="#section-2.1-2.1" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-2.1-2.2">
+            <code>aud</code> - the client_id of the client the response is intended for<a href="#section-2.1-2.2" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-2.1-2.3">
+            <code>exp</code> - expiration of the JWT. A maximum JWT lifetime of 10 minutes is RECOMMENDED.<a href="#section-2.1-2.3" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-2.1-3">The JWT MUST furthermore contain the authorization endpoint response parameters as defined for the particular response types, even in case of an error response. Authorization endpoint response parameter names and string values are included as JSON strings and numerical values (e.g., <code>expires_in</code> value) are included as JSON numbers. This pattern is applicable to all response types including those defined in <span>[<a href="#OIDM" class="cite xref">OIDM</a>]</span>. The following subsection illustrates the pattern for the response type "code".<a href="#section-2.1-3" class="pilcrow">¶</a></p>
+<p id="section-2.1-4">Note: Additional authorization endpoint response parameters defined by extensions, e.g. <code>session_state</code> as defined in <span>[<a href="#OISM" class="cite xref">OISM</a>]</span>, will also be added to the JWT.<a href="#section-2.1-4" class="pilcrow">¶</a></p>
+<p id="section-2.1-5">The JWT response document MAY contain further element, e.g. the claims defined in <span>[<a href="#RFC7519" class="cite xref">RFC7519</a>]</span>. Implementation SHOULD adhere to the respective processing rules and ignore unrecognized elements.<a href="#section-2.1-5" class="pilcrow">¶</a></p>
+<div id="example-response-type-code">
+<section id="section-2.1.1">
+          <h4 id="name-example-response-type-code">
+<a href="#section-2.1.1" class="section-number selfRef">2.1.1. </a><a href="#name-example-response-type-code" class="section-name selfRef">Example Response Type "code"</a>
+          </h4>
+<p id="section-2.1.1-1">For the grant type authorization "code" the JWT contains the response parameters as defined in <span>[<a href="#RFC6749" class="cite xref">RFC6749</a>]</span>, sections 4.1.2:<a href="#section-2.1.1-1" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-2.1.1-2.1">
+              <code>code</code> - the authorization code<a href="#section-2.1.1-2.1" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-2.1.1-2.2">
+              <code>state</code> - the state value as sent by the client in the authorization request, if the client included a <code>state</code> parameter<a href="#section-2.1.1-2.2" class="pilcrow">¶</a>
+</li>
+          </ul>
+<p id="section-2.1.1-3">The following example shows the JWT claims for a successful "code" authorization response:<a href="#section-2.1.1-3" class="pilcrow">¶</a></p>
+<div class="alignLeft art-text artwork" id="section-2.1.1-4">
+<pre>{
+   "iss":"https://accounts.example.com",
+   "aud":"s6BhdRkqt3",
+   "exp":1311281970,
+   "code":"PyyFaux2o7Q0YfXBU32jhw.5FXSQpvr8akv9CeRDSd0QA",
+   "state":"S8NJ7uqk5fY4EjNvP_G_FtyJu6pUsvH9jsYni9dMAJw"
+}
+</pre><a href="#section-2.1.1-4" class="pilcrow">¶</a>
+</div>
+<p id="section-2.1.1-5">In case of an error response, the JWT contains the error response parameters as defined in <span>[<a href="#RFC6749" class="cite xref">RFC6749</a>]</span>, sections 4.1.2.1:<a href="#section-2.1.1-5" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-2.1.1-6.1">
+              <code>error</code> - the error code<a href="#section-2.1.1-6.1" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-2.1.1-6.2">
+              <code>error_description</code> (OPTIONAL) - a human readable description of the error<a href="#section-2.1.1-6.2" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-2.1.1-6.3">
+              <code>error_uri</code> (OPTIONAL) - a URI identifying a human-readable web page with information about the error<a href="#section-2.1.1-6.3" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-2.1.1-6.4">
+              <code>state</code> - the state value as sent by the client in the authorization request (if applicable)<a href="#section-2.1.1-6.4" class="pilcrow">¶</a>
+</li>
+          </ul>
+<p id="section-2.1.1-7">The following example shows the JWT payload for such an error response:<a href="#section-2.1.1-7" class="pilcrow">¶</a></p>
+<div class="alignLeft art-text artwork" id="section-2.1.1-8">
+<pre>{
+   "iss":"https://accounts.example.com",
+   "aud":"s6BhdRkqt3",
+   "exp":1311281970,
+   "error":"access_denied",
+   "state":"S8NJ7uqk5fY4EjNvP_G_FtyJu6pUsvH9jsYni9dMAJw"
+}
+</pre><a href="#section-2.1.1-8" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="signing-and-encryption">
+<section id="section-2.2">
+        <h3 id="name-signing-and-encryption">
+<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-signing-and-encryption" class="section-name selfRef">Signing and Encryption</a>
+        </h3>
+<p id="section-2.2-1">The JWT is either signed, or signed and encrypted. If the JWT is both signed and encrypted, the JSON document will be signed then encrypted, with the result being a Nested JWT, as defined in <span>[<a href="#RFC7519" class="cite xref">RFC7519</a>]</span>.<a href="#section-2.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.2-2">The authorization server determines what algorithm to employ to secure the JWT for a particular authorization response. This decision can be based on registered metadata parameters for the client as defined by this document (see <a href="#client-metadata" class="auto internal xref">Section 3</a>).<a href="#section-2.2-2" class="pilcrow">¶</a></p>
+<p id="section-2.2-3">For guidance on key management in general and especially on use of symmetric algorithms for signing and encrypting based on client secrets see section 10 of <span>[<a href="#OIDC" class="cite xref">OIDC</a>]</span>.<a href="#section-2.2-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="response-encoding">
+<section id="section-2.3">
+        <h3 id="name-response-encoding">
+<a href="#section-2.3" class="section-number selfRef">2.3. </a><a href="#name-response-encoding" class="section-name selfRef">Response Encoding</a>
+        </h3>
+<p id="section-2.3-1">This document defines the following response mode values:<a href="#section-2.3-1" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-2.3-2.1">
+            <code>query.jwt</code><a href="#section-2.3-2.1" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-2.3-2.2">
+            <code>fragment.jwt</code><a href="#section-2.3-2.2" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-2.3-2.3">
+            <code>form_post.jwt</code><a href="#section-2.3-2.3" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-2.3-2.4">
+            <code>jwt</code><a href="#section-2.3-2.4" class="pilcrow">¶</a>
+</li>
+        </ul>
+<div id="response-mode-query-jwt">
+<section id="section-2.3.1">
+          <h4 id="name-response-mode-queryjwt">
+<a href="#section-2.3.1" class="section-number selfRef">2.3.1. </a><a href="#name-response-mode-queryjwt" class="section-name selfRef">Response Mode "query.jwt"</a>
+          </h4>
+<p id="section-2.3.1-1">The response mode "query.jwt" causes the authorization server to send the authorization response as HTTP redirect to the redirect URI of the client. The authorization server adds the parameter <code>response</code> containing the JWT as defined in <a href="#jwt-response" class="auto internal xref">Section 2.1</a>. to the query component of the redirect URI using the "application/x-www-form-urlencoded" format.<a href="#section-2.3.1-1" class="pilcrow">¶</a></p>
+<p id="section-2.3.1-2">This is an example response (line breaks for display purposes only):<a href="#section-2.3.1-2" class="pilcrow">¶</a></p>
+<div class="alignLeft art-text artwork" id="section-2.3.1-3">
+<pre>HTTP/1.1 302 Found
+Location: https://client.example.com/cb?
+response=eyJraWQiOiJsYWViIiwiYWxnIjoiRVMyNTYifQ.eyAgImlzcyI6ICJodHRwczovL2FjY291
+bnRzLmV4YW1wbGUuY29tIiwgICJhdWQiOiAiczZCaGRSa3F0MyIsICAiZXhwIjogMTMxMTI4MTk3MCwg
+ICJjb2RlIjogIlB5eUZhdXgybzdRMFlmWEJVMzJqaHcuNUZYU1FwdnI4YWt2OUNlUkRTZDBRQSIsICAi
+c3RhdGUiOiAiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2SDlqc1luaTlkTUFKdyJ9.4VdtknV
+Z9zFYDVLagJpVBD436bjPMcSgOaPDPFgTEkNyCs2uIHYJ2XML6d2w1AUsm5GBG77DBisZNhLWfug6dA
+</pre><a href="#section-2.3.1-3" class="pilcrow">¶</a>
+</div>
+<p id="section-2.3.1-4">Note: "query.jwt" MUST NOT be used in conjunction with response types that contain "token" or "id_token" unless the response JWT is encrypted to prevent token leakage in the URL.<a href="#section-2.3.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="response-mode-fragment-jwt">
+<section id="section-2.3.2">
+          <h4 id="name-response-mode-fragmentjwt">
+<a href="#section-2.3.2" class="section-number selfRef">2.3.2. </a><a href="#name-response-mode-fragmentjwt" class="section-name selfRef">Response Mode "fragment.jwt"</a>
+          </h4>
+<p id="section-2.3.2-1">The response mode "fragment.jwt" causes the authorization server to send the authorization response as HTTP redirect to the redirect URI of the client. The authorization server adds the parameter <code>response</code> containing the JWT as defined in <a href="#jwt-response" class="auto internal xref">Section 2.1</a>. to the fragment component of the redirect URI using the "application/x-www-form-urlencoded" format.<a href="#section-2.3.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.3.2-2">This is an example response (line breaks for display purposes only):<a href="#section-2.3.2-2" class="pilcrow">¶</a></p>
+<div class="alignLeft art-text artwork" id="section-2.3.2-3">
+<pre>HTTP/1.1 302 Found
+Location: https://client.example.com/cb#
+response=eyJraWQiOiJsYWViIiwiYWxnIjoiRVMyNTYifQ.eyAgImlzcyI6ICJodHRwczovL2FjY291
+bnRzLmV4YW1wbGUuY29tIiwgICJhdWQiOiAiczZCaGRSa3F0MyIsICAiZXhwIjogMTMxMTI4MTk3MCwg
+ICJhY2Nlc3NfdG9rZW4iOiAiMllvdG5GWkZFanIxekNzaWNNV3BBQSIsICAic3RhdGUiOiAiUzhOSjd1
+cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2SDlqc1luaTlkTUFKdyIsICAidG9rZW5fdHlwZSI6ICJiZWFy
+ZXIiLCAgImV4cGlyZXNfaW4iOiAzNjAwLCAgInNjb3BlIjogImV4YW1wbGUifQ.g_96IM2t_6Dazm1Jp
+b2gbO2EXe5IKTw2bYS7l9Y1RI8HbNPYN5EdNjxcWeL5LTQaUAZ2PtJoHbTdjMvNa3xbVg
+</pre><a href="#section-2.3.2-3" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+<div id="response-mode-form-post-jwt">
+<section id="section-2.3.3">
+          <h4 id="name-response-mode-form_postjwt">
+<a href="#section-2.3.3" class="section-number selfRef">2.3.3. </a><a href="#name-response-mode-form_postjwt" class="section-name selfRef">Response Mode "form_post.jwt"</a>
+          </h4>
+<p id="section-2.3.3-1">The response mode "form_post.jwt" uses the technique described in <span>[<a href="#OIFP" class="cite xref">OIFP</a>]</span> to convey the JWT to the client. The <code>response</code> parameter containing the JWT is encoded as HTML form value that is auto-submitted in the User Agent, and thus is transmitted via the HTTP POST method to the Client, with the result parameters being encoded in the body using the "application/x-www-form-urlencoded" format.<a href="#section-2.3.3-1" class="pilcrow">¶</a></p>
+<p id="section-2.3.3-2">This is an example response from the authorization server to the user agent (line breaks for display purposes only),<a href="#section-2.3.3-2" class="pilcrow">¶</a></p>
+<div class="alignLeft art-text artwork" id="section-2.3.3-3">
+<pre>HTTP/1.1 200 OK
+Content-Type: text/html;charset=UTF-8
+Cache-Control: no-cache, no-store
+Pragma: no-cache
+
+&lt;html&gt;
+ &lt;head&gt;&lt;title&gt;Submit This Form&lt;/title&gt;&lt;/head&gt;
+ &lt;body onload="javascript:document.forms[0].submit()"&gt;
+  &lt;form method="post" action="https://client.example.com/cb"&gt;
+    &lt;input type="hidden" name="response"
+     value="eyJraWQiOiJsYWViIiwiYWxnIjoiRVMyNTYifQ.eyAgImlzcyI6ICJodHRw
+     czovL2FjY291bnRzLmV4YW1wbGUuY29tIiwgICJhdWQiOiAiczZCaGRSa3F0MyIsIC
+     AiZXhwIjogMTMxMTI4MTk3MCwgICJhY2Nlc3NfdG9rZW4iOiAiMllvdG5GWkZFanIx
+     ekNzaWNNV3BBQSIsICAic3RhdGUiOiAiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdT
+     ZwVXN2SDlqc1luaTlkTUFKdyIsICAidG9rZW5fdHlwZSI6ICJiZWFyZXIiLCAgImV4
+     cGlyZXNfaW4iOiAzNjAwLCAgInNjb3BlIjogImV4YW1wbGUifQ.g_96IM2t_6Dazm1
+     Jpb2gbO2EXe5IKTw2bYS7l9Y1RI8HbNPYN5EdNjxcWeL5LTQaUAZ2PtJoHbTdjMvNa
+     3xbVg"/&gt;
+    &lt;/form&gt;
+   &lt;/body&gt;
+  &lt;/html&gt;
+</pre><a href="#section-2.3.3-3" class="pilcrow">¶</a>
+</div>
+<p id="section-2.3.3-4">which results in the following POST request to the client's redirect URI.<a href="#section-2.3.3-4" class="pilcrow">¶</a></p>
+<div class="alignLeft art-text artwork" id="section-2.3.3-5">
+<pre>POST /cb HTTP/1.1
+Host: client.example.org
+Content-Type: application/x-www-form-urlencoded
+
+response=eyJraWQiOiJsYWViIiwiYWxnIjoiRVMyNTYifQ.eyAgImlzcyI6ICJodHRw
+czovL2FjY291bnRzLmV4YW1wbGUuY29tIiwgICJhdWQiOiAiczZCaGRSa3F0MyIsICAi
+ZXhwIjogMTMxMTI4MTk3MCwgICJhY2Nlc3NfdG9rZW4iOiAiMllvdG5GWkZFanIxekNz
+aWNNV3BBQSIsICAic3RhdGUiOiAiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2
+SDlqc1luaTlkTUFKdyIsICAidG9rZW5fdHlwZSI6ICJiZWFyZXIiLCAgImV4cGlyZXNf
+aW4iOiAzNjAwLCAgInNjb3BlIjogImV4YW1wbGUifQ.g_96IM2t_6Dazm1Jpb2gbO2EX
+e5IKTw2bYS7l9Y1RI8HbNPYN5EdNjxcWeL5LTQaUAZ2PtJoHbTdjMvNa3xbVg
+</pre><a href="#section-2.3.3-5" class="pilcrow">¶</a>
+</div>
+</section>
+</div>
+<div id="response-mode-jwt">
+<section id="section-2.3.4">
+          <h4 id="name-response-mode-jwt">
+<a href="#section-2.3.4" class="section-number selfRef">2.3.4. </a><a href="#name-response-mode-jwt" class="section-name selfRef">Response Mode "jwt"</a>
+          </h4>
+<p id="section-2.3.4-1">The response mode "jwt" is a shortcut and indicates the default redirect encoding (query, fragment) for the requested response type. The default for response type "code" is "query.jwt" whereas the default for "token" and the response types defined in <span>[<a href="#OIDM" class="cite xref">OIDM</a>]</span>, except "none", is "fragment.jwt".<a href="#section-2.3.4-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="processing-rules">
+<section id="section-2.4">
+        <h3 id="name-processing-rules">
+<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-processing-rules" class="section-name selfRef">Processing rules</a>
+        </h3>
+<p id="section-2.4-1">Assumption: the client remembers the authorization server to which it sent the authorization request and binds this information to the user agent.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
+<p id="section-2.4-2">The client MUST process the JWT secured response as follows:<a href="#section-2.4-2" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-2.4-3">
+<li id="section-2.4-3.1">(OPTIONAL) The client decrypts the JWT using the default key for the respective issuer or, if applicable, determined by the <code>kid</code> JWT header parameter. The key might be a private key, where the corresponding public key is registered with the expected issuer of the response ("use":"enc" via the client's metadata <code>jwks</code> or <code>jwks_uri</code>) or a key derived from its client secret (see <a href="#signing-and-encryption" class="auto internal xref">Section 2.2</a>).<a href="#section-2.4-3.1" class="pilcrow">¶</a>
+</li>
+          <li id="section-2.4-3.2">The client obtains the <code>iss</code> element from the JWT and checks whether its value is well known and identifies the expected issuer of the authorization process in examination. If the check fails, the client MUST abort processing and refuse the response.<a href="#section-2.4-3.2" class="pilcrow">¶</a>
+</li>
+          <li id="section-2.4-3.3">The client obtains the <code>aud</code> element from the JWT and checks whether it matches the client id the client used to identify itself in the corresponding authorization request. If the check fails, the client MUST abort processing and refuse the response.<a href="#section-2.4-3.3" class="pilcrow">¶</a>
+</li>
+          <li id="section-2.4-3.4">The client checks the JWT's <code>exp</code> element to determine if the JWT is still valid. If the check fails, the client MUST abort processing and refuse the response.<a href="#section-2.4-3.4" class="pilcrow">¶</a>
+</li>
+          <li id="section-2.4-3.5">The client MUST check the signature of the JWT according to <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span> and the algorithm <code>none</code> (<code>"alg":"none"</code>) MUST NOT be accepted. If the check fails, the client MUST abort processing and refuse the response.<a href="#section-2.4-3.5" class="pilcrow">¶</a>
+</li>
+        </ol>
+<p id="section-2.4-4">The client will perform further checks, e.g. for CSRF detection, which are out of scope of this specification. Please see <span>[<a href="#RFC9700" class="cite xref">RFC9700</a>]</span> for more security recommendations.<a href="#section-2.4-4" class="pilcrow">¶</a></p>
+<p id="section-2.4-5">Note: The way the client obtains the keys for verifying the JWT's signature (step 5) is out of scope of this document. Established mechanism such as <span>[<a href="#OIDD" class="cite xref">OIDD</a>]</span> or <span>[<a href="#RFC8414" class="cite xref">RFC8414</a>]</span> SHOULD be utilized.<a href="#section-2.4-5" class="pilcrow">¶</a></p>
+<p id="section-2.4-6">The client MUST NOT process the grant type specific authorization response parameters before all checks succeed.<a href="#section-2.4-6" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="client-metadata">
+<section id="section-3">
+      <h2 id="name-client-metadata">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-client-metadata" class="section-name selfRef">Client Metadata</a>
+      </h2>
+<p id="section-3-1">The Dynamic Client Registration Protocol <span>[<a href="#RFC7591" class="cite xref">RFC7591</a>]</span> defines an API
+for dynamically registering OAuth 2.0 client metadata with authorization servers.
+The metadata defined by <span>[<a href="#RFC7591" class="cite xref">RFC7591</a>]</span>, and registered extensions to it,
+also imply a general data model for clients that is useful for authorization server implementations
+even when the Dynamic Client Registration Protocol isn't in play.
+Such implementations will typically have some sort of user interface available for managing client configuration.<a href="#section-3-1" class="pilcrow">¶</a></p>
+<p id="section-3-2">The following client metadata parameters are introduced by this specification:<a href="#section-3-2" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlCompact dlParallel" id="section-3-3">
+        <dt id="section-3-3.1"><code>authorization_signed_response_alg</code></dt>
+        <dd style="margin-left: 1.5em" id="section-3-3.2">The JWS <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span> <code>alg</code> algorithm REQUIRED for signing authorization responses. If this is specified, the response will be signed using JWS and the configured algorithm. If unspecified, the default algorithm to use for signing authorization responses is <code>RS256</code>. The algorithm <code>none</code> is not allowed.<a href="#section-3-3.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-3.3"><code>authorization_encrypted_response_alg</code></dt>
+        <dd style="margin-left: 1.5em" id="section-3-3.4">The JWE <span>[<a href="#RFC7516" class="cite xref">RFC7516</a>]</span> <code>alg</code> algorithm REQUIRED for encrypting authorization responses.  If both signing and encryption are requested, the response will be signed then encrypted, with the result being a Nested JWT, as defined in JWT <span>[<a href="#RFC7519" class="cite xref">RFC7519</a>]</span>.  The default, if omitted, is that no encryption is performed.<a href="#section-3-3.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-3.5"><code>authorization_encrypted_response_enc</code></dt>
+        <dd style="margin-left: 1.5em" id="section-3-3.6">The JWE <span>[<a href="#RFC7516" class="cite xref">RFC7516</a>]</span> <code>enc</code> algorithm REQUIRED for encrypting authorization responses.  If <code>authorization_encrypted_response_alg</code> is specified, the default for this value is <code>A128CBC-HS256</code>.  When <code>authorization_encrypted_response_enc</code> is included, <code>authorization_encrypted_response_alg</code> MUST also be provided.<a href="#section-3-3.6" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<p id="section-3-4">The <code>jwks_uri</code> or <code>jwks</code> metadata parameters can be used by clients to register their public encryption keys.<a href="#section-3-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="as-metadata">
+<section id="section-4">
+      <h2 id="name-authorization-server-metada">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-authorization-server-metada" class="section-name selfRef">Authorization Server Metadata</a>
+      </h2>
+<p id="section-4-1">Authorization servers SHOULD publish the supported algorithms for signing and encrypting the JWT of an authorization response by utilizing OAuth 2.0 Authorization Server Metadata <span>[<a href="#RFC8414" class="cite xref">RFC8414</a>]</span> parameters.<a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-4-2">The following parameters are introduced by this specification:<a href="#section-4-2" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlCompact dlParallel" id="section-4-3">
+        <dt id="section-4-3.1"><code>authorization_signing_alg_values_supported</code></dt>
+        <dd style="margin-left: 1.5em" id="section-4-3.2">OPTIONAL.  A JSON array containing a list of the JWS <span>[<a href="#RFC7515" class="cite xref">RFC7515</a>]</span> signing algorithms (<code>alg</code> values) supported by the authorization endpoint to sign the response.<a href="#section-4-3.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-4-3.3"><code>authorization_encryption_alg_values_supported</code></dt>
+        <dd style="margin-left: 1.5em" id="section-4-3.4">OPTIONAL.  A JSON array containing a list of the JWE <span>[<a href="#RFC7516" class="cite xref">RFC7516</a>]</span> encryption algorithms (<code>alg</code> values) supported by the authorization endpoint to encrypt the response.<a href="#section-4-3.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-4-3.5"><code>authorization_encryption_enc_values_supported</code></dt>
+        <dd style="margin-left: 1.5em" id="section-4-3.6">OPTIONAL.  A JSON array containing a list of the JWE <span>[<a href="#RFC7516" class="cite xref">RFC7516</a>]</span> encryption algorithms (<code>enc</code> values)  supported by the authorization endpoint to encrypt the response.<a href="#section-4-3.6" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<p id="section-4-4">Authorization servers SHOULD publish the supported response mode values utilizing the parameter <code>response_modes_supported</code> as defined in <span>[<a href="#RFC8414" class="cite xref">RFC8414</a>]</span>. This document introduces the following possible values:<a href="#section-4-4" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-4-5.1">
+          <code>query.jwt</code><a href="#section-4-5.1" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="section-4-5.2">
+          <code>fragment.jwt</code><a href="#section-4-5.2" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="section-4-5.3">
+          <code>form_post.jwt</code><a href="#section-4-5.3" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="section-4-5.4">
+          <code>jwt</code><a href="#section-4-5.4" class="pilcrow">¶</a>
+</li>
+      </ul>
+</section>
+</div>
+<div id="security-considerations">
+<section id="section-5">
+      <h2 id="name-security-considerations">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+      </h2>
+<p id="section-5-1">As JARM is used as a component in OAuth, many of the security considerations listed in OAuth 2.0 Security Best Current Practice <span>[<a href="#RFC9700" class="cite xref">RFC9700</a>]</span> apply. In addition, for the mechanisms described in this document, the following security considerations apply.<a href="#section-5-1" class="pilcrow">¶</a></p>
+<div id="dos-using-specially-crafted-jwts">
+<section id="section-5.1">
+        <h3 id="name-dos-using-specially-crafted">
+<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-dos-using-specially-crafted" class="section-name selfRef">DoS using specially crafted JWTs</a>
+        </h3>
+<p id="section-5.1-1">JWTs could be crafted to have an issuer that resolves to a JWK set URL with
+huge content, or is delivered very slowly, consuming server networking
+bandwidth and compute capacity. The resolved JWK set URL could also be used to
+DDoS targets on the web.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
+<p id="section-5.1-2">The client therefore MUST first check that the issuer of the JWT is well-known
+and expected for the particular authorization response before it uses this data
+to obtain the key needed to check the JWT's signature.<a href="#section-5.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="protocol-run-integrity">
+<section id="section-5.2">
+        <h3 id="name-protocol-run-integrity">
+<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-protocol-run-integrity" class="section-name selfRef">Protocol Run Integrity</a>
+        </h3>
+<p id="section-5.2-1">An OAuth protocol run is made of many distinct message exchanges between the client and server
+to complete the issuance of access and refresh tokens. Even if every message itself is integrity
+protected, it is still conceivable that one or more of the messages are exchanged with another
+message created for a different protocol run. The leakage and reuse of encrypted messages in
+<a href="#code-leakage" class="auto internal xref">Section 5.4</a> is an example of such problems. To mitigate this problem, it is considered good
+practice to implement additional protection provided by PKCE <span>[<a href="#RFC7636" class="cite xref">RFC7636</a>]</span>
+as described in <span>[<a href="#RFC9700" class="cite xref">RFC9700</a>]</span>.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="mix-up">
+<section id="section-5.3">
+        <h3 id="name-mix-up">
+<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-mix-up" class="section-name selfRef">Mix-Up</a>
+        </h3>
+<p id="section-5.3-1">Mix-up is an attack on scenarios where an OAuth client interacts with
+multiple authorization servers. The goal of the attack is to obtain an
+authorization code or an access token by tricking the client into
+sending those credentials to the attacker instead of using them at
+the respective endpoint at the authorization/resource server.<a href="#section-5.3-1" class="pilcrow">¶</a></p>
+<p id="section-5.3-2">The JWT secured response mode enables clients to detect this attack by providing an identification of the sender (<code>iss</code>) and the intended audience of the authorization response (<code>aud</code>).<a href="#section-5.3-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="code-leakage">
+<section id="section-5.4">
+        <h3 id="name-code-leakage">
+<a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-code-leakage" class="section-name selfRef">Code Leakage</a>
+        </h3>
+<p id="section-5.4-1">Authorization servers MAY encrypt the authorization response therewith providing a means to prevent leakage of authorization codes in the user agent (e.g. during transmission, in browser history or via referrer headers).
+Note, however, that the entire response is then potentially subject to leakage. An encrypted response doesn't remove the need for additional protections provided by mechanisms such as PKCE <span>[<a href="#RFC7636" class="cite xref">RFC7636</a>]</span>.<a href="#section-5.4-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="privacy-considerations">
+<section id="section-6">
+      <h2 id="name-privacy-considerations">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-privacy-considerations" class="section-name selfRef">Privacy Considerations</a>
+      </h2>
+<p id="section-6-1">JARM only defines an alternative way of encoding the authorization response message and therefore does not materially impact the privacy considerations
+of OAuth 2.0, which is a complex and flexible framework with broad-ranging privacy implications.<a href="#section-6-1" class="pilcrow">¶</a></p>
+<p id="section-6-2">The content of a conventional authorization response message (e.g., <code>code</code> and <code>state</code>) does not typically convey personally identifiable information (PII). However, using encrypted JARM may improve privacy by reducing the potential for inadvertent information disclosure in cases where the authorization response might contain PII (such as other response types or extensions).<a href="#section-6-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="iana-considerations">
+<section id="section-7">
+      <h2 id="name-iana-considerations">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+      </h2>
+<div id="oauth-dynamic-client-registration-metadata-registration">
+<section id="section-7.1">
+        <h3 id="name-oauth-dynamic-client-regist">
+<a href="#section-7.1" class="section-number selfRef">7.1. </a><a href="#name-oauth-dynamic-client-regist" class="section-name selfRef">OAuth Dynamic Client Registration Metadata Registration</a>
+        </h3>
+<p id="section-7.1-1">This specification requests registration of the following client metadata definitions in the IANA "OAuth Dynamic Client Registration Metadata" registry established by <span>[<a href="#RFC7591" class="cite xref">RFC7591</a>]</span>:<a href="#section-7.1-1" class="pilcrow">¶</a></p>
+<div id="registry-contents">
+<section id="section-7.1.1">
+          <h4 id="name-registry-contents">
+<a href="#section-7.1.1" class="section-number selfRef">7.1.1. </a><a href="#name-registry-contents" class="section-name selfRef">Registry Contents</a>
+          </h4>
+<ul class="compact">
+<li class="compact" id="section-7.1.1-1.1">Client Metadata Name: <code>authorization_signed_response_alg</code><a href="#section-7.1.1-1.1" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.1.1-1.2">Client Metadata Description: String value indicating the client's desired authorization response signing algorithm.<a href="#section-7.1.1-1.2" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.1.1-1.3">Change Controller: IESG<a href="#section-7.1.1-1.3" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.1.1-1.4">Specification Document(s): <a href="#client-metadata" class="auto internal xref">Section 3</a> of this specification<a href="#section-7.1.1-1.4" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.1.1-1.5">Client Metadata Name: <code>authorization_encrypted_response_alg</code><a href="#section-7.1.1-1.5" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.1.1-1.6">Client Metadata Description: String value specifying the desired authorization response encryption algorithm (alg value).<a href="#section-7.1.1-1.6" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.1.1-1.7">Change Controller: IESG<a href="#section-7.1.1-1.7" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.1.1-1.8">Specification Document(s): <a href="#client-metadata" class="auto internal xref">Section 3</a> of this specification<a href="#section-7.1.1-1.8" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.1.1-1.9">Client Metadata Name: <code>authorization_encrypted_response_enc</code><a href="#section-7.1.1-1.9" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.1.1-1.10">Client Metadata Description: String value specifying the desired authorization response encryption algorithm (enc value).<a href="#section-7.1.1-1.10" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.1.1-1.11">Change Controller: IESG<a href="#section-7.1.1-1.11" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.1.1-1.12">Specification Document(s): <a href="#client-metadata" class="auto internal xref">Section 3</a> of this specification<a href="#section-7.1.1-1.12" class="pilcrow">¶</a>
+</li>
+          </ul>
+</section>
+</div>
+</section>
+</div>
+<div id="oauth-authorization-server-metadata-registration">
+<section id="section-7.2">
+        <h3 id="name-oauth-authorization-server-">
+<a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-oauth-authorization-server-" class="section-name selfRef">OAuth Authorization Server Metadata Registration</a>
+        </h3>
+<p id="section-7.2-1">This specification requests registration of the following value in the IANA "OAuth Authorization Server Metadata" registry established by <span>[<a href="#RFC8414" class="cite xref">RFC8414</a>]</span>.<a href="#section-7.2-1" class="pilcrow">¶</a></p>
+<div id="registry-contents-1">
+<section id="section-7.2.1">
+          <h4 id="name-registry-contents-2">
+<a href="#section-7.2.1" class="section-number selfRef">7.2.1. </a><a href="#name-registry-contents-2" class="section-name selfRef">Registry Contents</a>
+          </h4>
+<ul class="compact">
+<li class="compact" id="section-7.2.1-1.1">Metadata Name: <code>authorization_signing_alg_values_supported</code><a href="#section-7.2.1-1.1" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.2.1-1.2">Metadata Description: JSON array containing a list of algorithms supported by the authorization server for authorization response signing.<a href="#section-7.2.1-1.2" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.2.1-1.3">Change Controller: IESG<a href="#section-7.2.1-1.3" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.2.1-1.4">Specification Document(s): <a href="#as-metadata" class="auto internal xref">Section 4</a> of this specification<a href="#section-7.2.1-1.4" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.2.1-1.5">Metadata Name: <code>authorization_encryption_alg_values_supported</code><a href="#section-7.2.1-1.5" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.2.1-1.6">Metadata Description: JSON array containing a list of algorithms supported by the authorization server for authorization response encryption (alg value).<a href="#section-7.2.1-1.6" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.2.1-1.7">Change Controller: IESG<a href="#section-7.2.1-1.7" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.2.1-1.8">Specification Document(s): <a href="#as-metadata" class="auto internal xref">Section 4</a> of this specification<a href="#section-7.2.1-1.8" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.2.1-1.9">Metadata Name: <code>authorization_encryption_enc_values_supported</code><a href="#section-7.2.1-1.9" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.2.1-1.10">Metadata Description: JSON array containing a list of algorithms supported by the authorization server for authorization response encryption (enc value).<a href="#section-7.2.1-1.10" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.2.1-1.11">Change Controller: IESG<a href="#section-7.2.1-1.11" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-7.2.1-1.12">Specification Document(s): <a href="#as-metadata" class="auto internal xref">Section 4</a> of this specification<a href="#section-7.2.1-1.12" class="pilcrow">¶</a>
+</li>
+          </ul>
+</section>
+</div>
+</section>
+</div>
+</section>
+</div>
+<section id="section-8">
+      <h2 id="name-normative-references">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+      </h2>
+<dl class="references">
+<dt id="OIDM">[OIDM]</dt>
+      <dd>
+<span class="refAuthor">de Medeiros, B., Ed.</span>, <span class="refAuthor">Scurtescu, M.</span>, <span class="refAuthor">Tarjan, P.</span>, and <span class="refAuthor">M.B. Jones</span>, <span class="refTitle">"OAuth 2.0 Multiple Response Type Encoding Practices"</span>, <time datetime="2014-02-25" class="refDate">25 February 2014</time>, <span>&lt;<a href="http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html">http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="OIFP">[OIFP]</dt>
+      <dd>
+<span class="refAuthor">Jones, M.</span> and <span class="refAuthor">B. Campbell</span>, <span class="refTitle">"OAuth 2.0 Form Post Response Mode"</span>, <time datetime="2015-04-27" class="refDate">27 April 2015</time>, <span>&lt;<a href="https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html">https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC2119">[RFC2119]</dt>
+      <dd>
+<span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03" class="refDate">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC6749">[RFC6749]</dt>
+      <dd>
+<span class="refAuthor">Hardt, D., Ed.</span>, <span class="refTitle">"The OAuth 2.0 Authorization Framework"</span>, <span class="seriesInfo">RFC 6749</span>, <span class="seriesInfo">DOI 10.17487/RFC6749</span>, <time datetime="2012-10" class="refDate">October 2012</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc6749">https://www.rfc-editor.org/info/rfc6749</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7515">[RFC7515]</dt>
+      <dd>
+<span class="refAuthor">Jones, M.</span>, <span class="refAuthor">Bradley, J.</span>, and <span class="refAuthor">N. Sakimura</span>, <span class="refTitle">"JSON Web Signature (JWS)"</span>, <span class="seriesInfo">RFC 7515</span>, <span class="seriesInfo">DOI 10.17487/RFC7515</span>, <time datetime="2015-05" class="refDate">May 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7515">https://www.rfc-editor.org/info/rfc7515</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7516">[RFC7516]</dt>
+      <dd>
+<span class="refAuthor">Jones, M.</span> and <span class="refAuthor">J. Hildebrand</span>, <span class="refTitle">"JSON Web Encryption (JWE)"</span>, <span class="seriesInfo">RFC 7516</span>, <span class="seriesInfo">DOI 10.17487/RFC7516</span>, <time datetime="2015-05" class="refDate">May 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7516">https://www.rfc-editor.org/info/rfc7516</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7519">[RFC7519]</dt>
+      <dd>
+<span class="refAuthor">Jones, M.</span>, <span class="refAuthor">Bradley, J.</span>, and <span class="refAuthor">N. Sakimura</span>, <span class="refTitle">"JSON Web Token (JWT)"</span>, <span class="seriesInfo">RFC 7519</span>, <span class="seriesInfo">DOI 10.17487/RFC7519</span>, <time datetime="2015-05" class="refDate">May 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7519">https://www.rfc-editor.org/info/rfc7519</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8174">[RFC8174]</dt>
+    <dd>
+<span class="refAuthor">Leiba, B.</span>, <span class="refTitle">"Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 8174</span>, <span class="seriesInfo">DOI 10.17487/RFC8174</span>, <time datetime="2017-05" class="refDate">May 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8174">https://www.rfc-editor.org/info/rfc8174</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<section id="section-9">
+      <h2 id="name-informative-references">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+      </h2>
+<dl class="references">
+<dt id="OIDC">[OIDC]</dt>
+      <dd>
+<span class="refAuthor">Sakimura, N.</span>, <span class="refAuthor">Bradley, J.</span>, <span class="refAuthor">Jones, M.</span>, <span class="refAuthor">de Medeiros, B.</span>, and <span class="refAuthor">C. Mortimore</span>, <span class="refTitle">"OpenID Connect Core 1.0 incorporating errata set 1"</span>, <time datetime="2014-11-08" class="refDate">8 November 2014</time>, <span>&lt;<a href="http://openid.net/specs/openid-connect-core-1_0.html">http://openid.net/specs/openid-connect-core-1_0.html</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="OIDD">[OIDD]</dt>
+      <dd>
+<span class="refAuthor">Sakimura, N.</span>, <span class="refAuthor">Bradley, J.</span>, <span class="refAuthor">Jones, M.</span>, and <span class="refAuthor">E. Jay</span>, <span class="refTitle">"OpenID Connect Discovery 1.0 incorporating errata set 1"</span>, <time datetime="2014-11-08" class="refDate">8 November 2014</time>, <span>&lt;<a href="https://openid.net/specs/openid-connect-discovery-1_0.html">https://openid.net/specs/openid-connect-discovery-1_0.html</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="OISM">[OISM]</dt>
+      <dd>
+<span class="refAuthor">de Medeiros, B.</span>, <span class="refAuthor">Agarwal, N.</span>, <span class="refAuthor">Sakimura, N.</span>, <span class="refAuthor">Bradley, J.</span>, and <span class="refAuthor">M.B. Jones</span>, <span class="refTitle">"OpenID Connect Session Management 1.0"</span>, <time datetime="2022-03-14" class="refDate">14 March 2022</time>, <span>&lt;<a href="http://openid.net/specs/openid-connect-session-1_0.html">http://openid.net/specs/openid-connect-session-1_0.html</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7591">[RFC7591]</dt>
+      <dd>
+<span class="refAuthor">Richer, J., Ed.</span>, <span class="refAuthor">Jones, M.</span>, <span class="refAuthor">Bradley, J.</span>, <span class="refAuthor">Machulak, M.</span>, and <span class="refAuthor">P. Hunt</span>, <span class="refTitle">"OAuth 2.0 Dynamic Client Registration Protocol"</span>, <span class="seriesInfo">RFC 7591</span>, <span class="seriesInfo">DOI 10.17487/RFC7591</span>, <time datetime="2015-07" class="refDate">July 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7591">https://www.rfc-editor.org/info/rfc7591</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7636">[RFC7636]</dt>
+      <dd>
+<span class="refAuthor">Sakimura, N., Ed.</span>, <span class="refAuthor">Bradley, J.</span>, and <span class="refAuthor">N. Agarwal</span>, <span class="refTitle">"Proof Key for Code Exchange by OAuth Public Clients"</span>, <span class="seriesInfo">RFC 7636</span>, <span class="seriesInfo">DOI 10.17487/RFC7636</span>, <time datetime="2015-09" class="refDate">September 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7636">https://www.rfc-editor.org/info/rfc7636</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8414">[RFC8414]</dt>
+      <dd>
+<span class="refAuthor">Jones, M.</span>, <span class="refAuthor">Sakimura, N.</span>, and <span class="refAuthor">J. Bradley</span>, <span class="refTitle">"OAuth 2.0 Authorization Server Metadata"</span>, <span class="seriesInfo">RFC 8414</span>, <span class="seriesInfo">DOI 10.17487/RFC8414</span>, <time datetime="2018-06" class="refDate">June 2018</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8414">https://www.rfc-editor.org/info/rfc8414</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9700">[RFC9700]</dt>
+    <dd>
+<span class="refAuthor">Lodderstedt, T.</span>, <span class="refAuthor">Bradley, J.</span>, <span class="refAuthor">Labunets, A.</span>, and <span class="refAuthor">D. Fett</span>, <span class="refTitle">"Best Current Practice for OAuth 2.0 Security"</span>, <span class="seriesInfo">BCP 240</span>, <span class="seriesInfo">RFC 9700</span>, <span class="seriesInfo">DOI 10.17487/RFC9700</span>, <time datetime="2025-01" class="refDate">January 2025</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9700">https://www.rfc-editor.org/info/rfc9700</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<div id="acknowledgements">
+<section id="appendix-A">
+      <h2 id="name-acknowledgements">
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+      </h2>
+<p id="appendix-A-1">The following people contributed to this document:<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="appendix-A-2.1">Torsten Lodderstedt (SPRIND), Editor<a href="#appendix-A-2.1" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-A-2.2">Brian Campbell (Ping Identity), Co-editor<a href="#appendix-A-2.2" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-A-2.3">Nat Sakimura (NAT Consulting LLC) -- Chair<a href="#appendix-A-2.3" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-A-2.4">Dave Tonge (Moneyhub) -- Chair<a href="#appendix-A-2.4" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-A-2.5">Joseph Heenan (Authlete)<a href="#appendix-A-2.5" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-A-2.6">Ralph Bragg (Raidiam)<a href="#appendix-A-2.6" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-A-2.7">Vladimir Dzhuvinov (Connect2ID)<a href="#appendix-A-2.7" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-A-2.8">Michael Schwartz (Gluu)<a href="#appendix-A-2.8" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-A-2.9">Filip Skokan (Auth0|Okta)<a href="#appendix-A-2.9" class="pilcrow">¶</a>
+</li>
+      </ul>
+</section>
+</div>
+<div id="notices">
+<section id="appendix-B">
+      <h2 id="name-notices">
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-notices" class="section-name selfRef">Notices</a>
+      </h2>
+<p id="appendix-B-1">Copyright (c) 2025 The OpenID Foundation.<a href="#appendix-B-1" class="pilcrow">¶</a></p>
+<p id="appendix-B-2">The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
+or other interested party a non-exclusive, royalty free, worldwide copyright license to
+reproduce, prepare derivative works from, distribute, perform and display, this
+Implementers Draft, Final Specification, or Final Specification Incorporating Errata
+Corrections solely for the purposes of (i) developing specifications, and (ii)
+implementing Implementers Drafts, Final Specifications, and Final Specification
+Incorporating Errata Corrections based on such documents, provided that attribution
+be made to the OIDF as the source of the material, but that such attribution does not
+indicate an endorsement by the OIDF.<a href="#appendix-B-2" class="pilcrow">¶</a></p>
+<p id="appendix-B-3">The technology described in this specification was made available from contributions
+from various sources, including members of the OpenID Foundation and others.
+Although the OpenID Foundation has taken steps to help ensure that the technology
+is available for distribution, it takes no position regarding the validity or scope of any
+intellectual property or other rights that might be claimed to pertain to the
+implementation or use of the technology described in this specification or the extent
+to which any license under such rights might or might not be available; neither does it
+represent that it has made any independent effort to identify any such rights. The
+OpenID Foundation and the contributors to this specification make no (and hereby
+expressly disclaim any) warranties (express, implied, or otherwise), including implied
+warranties of merchantability, non-infringement, fitness for a particular purpose, or
+title, related to this specification, and the entire risk as to implementing this
+specification is assumed by the implementer. The OpenID Intellectual Property
+Rights policy (found at openid.net) requires contributors to offer a patent promise not
+to assert certain patent claims against other contributors and against implementers.
+OpenID invites any interested party to bring to its attention any copyrights, patents,
+patent applications, or other proprietary rights that may cover technology that may be
+required to practice this specification.<a href="#appendix-B-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="document-history">
+<section id="appendix-C">
+      <h2 id="name-document-history">
+<a href="#appendix-C" class="section-number selfRef">Appendix C. </a><a href="#name-document-history" class="section-name selfRef">Document History</a>
+      </h2>
+<p id="appendix-C-1">[[ To be removed from the approved specification incorporating errata corrections ]]<a href="#appendix-C-1" class="pilcrow">¶</a></p>
+<p id="appendix-C-2">-05<a href="#appendix-C-2" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="appendix-C-3.1">Resolve JARM IANA registration review feedback<a href="#appendix-C-3.1" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-C-3.2">Update copyright notice<a href="#appendix-C-3.2" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-C-3.3">Update author and contributor associations<a href="#appendix-C-3.3" class="pilcrow">¶</a>
+</li>
+        <li class="compact" id="appendix-C-3.4">Update security topics reference to RFC970<a href="#appendix-C-3.4" class="pilcrow">¶</a>
+</li>
+      </ul>
+</section>
+</div>
+<div id="authors-addresses">
+<section id="appendix-D">
+      <h2 id="name-authors-addresses">
+<a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
+      </h2>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Torsten Lodderstedt</span></div>
+<div dir="auto" class="left"><span class="org">SPRIND</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:torsten@lodderstedt.net" class="email">torsten@lodderstedt.net</a>
+</div>
+</address>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Brian Campbell</span></div>
+<div dir="auto" class="left"><span class="org">Ping Identity</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:bcampbell@pingidentity.com" class="email">bcampbell@pingidentity.com</a>
+</div>
+</address>
+</section>
+</div>
+<script>const toc = document.getElementById("toc");
+toc.querySelector("h2").addEventListener("click", e => {
+  toc.classList.toggle("active");
+});
+toc.querySelector("nav").addEventListener("click", e => {
+  toc.classList.remove("active");
+});
+</script>
+</body>
+</html>

--- a/sync/specs/oauth-v2-jarm-05.md
+++ b/sync/specs/oauth-v2-jarm-05.md
@@ -1,0 +1,517 @@
+%%%
+title = "JWT Secured Authorization Response Mode for OAuth 2.0 (JARM) - Draft 05 incorporating errata set 1"
+abbrev = "OAuth JARM"
+ipr = "none"
+workgroup = "FAPI"
+keyword = ["security", "oauth2"]
+
+[seriesInfo]
+name = "Internet-Draft"
+value = "oauth-v2-jarm-05"
+status = "standard"
+
+[[author]]
+initials="T."
+surname="Lodderstedt"
+fullname="Torsten Lodderstedt"
+organization="SPRIND"
+    [author.address]
+    email = "torsten@lodderstedt.net"
+
+[[author]]
+initials="B."
+surname="Campbell"
+fullname="Brian Campbell"
+organization="Ping Identity"
+    [author.address]
+    email = "bcampbell@pingidentity.com"
+
+%%%
+
+
+{mainmatter}
+
+# Introduction
+
+This document defines a new JWT-based mode to encode OAuth authorization responses. Clients are enabled to request
+the transmission of the authorization response parameters along with additional data in JWT format.
+This mechanism enhances the security of the standard authorization response with support for signing and optional encryption of the response.
+A signed response provides message integrity, sender authentication, audience restriction, and protection from mix-up attacks. Encrypting the response provides confidentiality of the response parameter values.
+The JWT authorization response mode can be used in conjunction with any response type.
+
+## Notational Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
+NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED",
+"MAY", and "OPTIONAL" in this document are to be interpreted as
+described in BCP 14 [@!RFC2119] [@!RFC8174] when, and only when, they
+appear in all capitals, as shown here.
+
+## Terms and definitions
+For the purpose of this document, the terms defined in [@!RFC6749] and [@OIDC] apply.
+
+## Symbols and Abbreviated terms
+
+**API** – Application Programming Interface
+
+**CSRF** - Cross Site Request Forgery
+
+**HTTP** – Hyper Text Transfer Protocol
+
+**OIDF** - OpenID Foundation
+
+**TLS** – Transport Layer Security
+
+# JWT-based Response Mode
+
+This document defines a new JWT-based [@!RFC7519] mode to encode OAuth [@!RFC6749] authorization response parameters. All response parameters defined for a given response type are conveyed in a JWT along with additional claims used to further protect the transmission. Since there are different techniques to encode the JWT itself in the response to the client, namely query URI parameter, fragment component and form post, this document defines a set of response mode values in accordance with [@!OIDM] corresponding to these techniques.
+
+## The JWT Response Document {#jwt-response}
+
+The JWT always contains the following data utilized to secure the transmission:
+
+* `iss` - the issuer URL of the authorization server that created the response
+* `aud` - the client_id of the client the response is intended for
+* `exp` - expiration of the JWT. A maximum JWT lifetime of 10 minutes is RECOMMENDED.
+ 
+The JWT MUST furthermore contain the authorization endpoint response parameters as defined for the particular response types, even in case of an error response. Authorization endpoint response parameter names and string values are included as JSON strings and numerical values (e.g., `expires_in` value) are included as JSON numbers. This pattern is applicable to all response types including those defined in [@!OIDM]. The following subsection illustrates the pattern for the response type "code".
+
+Note: Additional authorization endpoint response parameters defined by extensions, e.g. `session_state` as defined in [@OISM], will also be added to the JWT. 
+
+The JWT response document MAY contain further element, e.g. the claims defined in [@!RFC7519]. Implementation SHOULD adhere to the respective processing rules and ignore unrecognized elements.
+
+### Example Response Type "code" 
+
+For the grant type authorization "code" the JWT contains the response parameters as defined in [@!RFC6749], sections 4.1.2:
+
+* `code` - the authorization code
+* `state` - the state value as sent by the client in the authorization request, if the client included a `state` parameter
+
+The following example shows the JWT claims for a successful "code" authorization response:
+
+```
+{  
+   "iss":"https://accounts.example.com",
+   "aud":"s6BhdRkqt3",
+   "exp":1311281970,
+   "code":"PyyFaux2o7Q0YfXBU32jhw.5FXSQpvr8akv9CeRDSd0QA",  
+   "state":"S8NJ7uqk5fY4EjNvP_G_FtyJu6pUsvH9jsYni9dMAJw"
+}
+```
+
+In case of an error response, the JWT contains the error response parameters as defined in [@!RFC6749], sections 4.1.2.1:
+
+* `error` - the error code
+* `error_description` (OPTIONAL) - a human readable description of the error
+* `error_uri` (OPTIONAL) - a URI identifying a human-readable web page with information about the error
+* `state` - the state value as sent by the client in the authorization request (if applicable)
+
+The following example shows the JWT payload for such an error response:
+
+```
+{
+   "iss":"https://accounts.example.com",
+   "aud":"s6BhdRkqt3",
+   "exp":1311281970,
+   "error":"access_denied",
+   "state":"S8NJ7uqk5fY4EjNvP_G_FtyJu6pUsvH9jsYni9dMAJw"
+}
+```
+
+## Signing and Encryption {#signing-and-encryption}
+
+The JWT is either signed, or signed and encrypted. If the JWT is both signed and encrypted, the JSON document will be signed then encrypted, with the result being a Nested JWT, as defined in [@!RFC7519].
+
+The authorization server determines what algorithm to employ to secure the JWT for a particular authorization response. This decision can be based on registered metadata parameters for the client as defined by this document (see (#client-metadata)).
+
+For guidance on key management in general and especially on use of symmetric algorithms for signing and encrypting based on client secrets see section 10 of [@OIDC].
+
+## Response Encoding
+
+This document defines the following response mode values:
+
+* `query.jwt`
+* `fragment.jwt`
+* `form_post.jwt`
+* `jwt`
+
+### Response Mode "query.jwt"
+
+The response mode "query.jwt" causes the authorization server to send the authorization response as HTTP redirect to the redirect URI of the client. The authorization server adds the parameter `response` containing the JWT as defined in (#jwt-response). to the query component of the redirect URI using the "application/x-www-form-urlencoded" format.
+
+This is an example response (line breaks for display purposes only): 
+
+```
+HTTP/1.1 302 Found
+Location: https://client.example.com/cb?
+response=eyJraWQiOiJsYWViIiwiYWxnIjoiRVMyNTYifQ.eyAgImlzcyI6ICJodHRwczovL2FjY291
+bnRzLmV4YW1wbGUuY29tIiwgICJhdWQiOiAiczZCaGRSa3F0MyIsICAiZXhwIjogMTMxMTI4MTk3MCwg
+ICJjb2RlIjogIlB5eUZhdXgybzdRMFlmWEJVMzJqaHcuNUZYU1FwdnI4YWt2OUNlUkRTZDBRQSIsICAi
+c3RhdGUiOiAiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2SDlqc1luaTlkTUFKdyJ9.4VdtknV
+Z9zFYDVLagJpVBD436bjPMcSgOaPDPFgTEkNyCs2uIHYJ2XML6d2w1AUsm5GBG77DBisZNhLWfug6dA
+```
+
+Note: "query.jwt" MUST NOT be used in conjunction with response types that contain "token" or "id_token" unless the response JWT is encrypted to prevent token leakage in the URL. 
+
+### Response Mode "fragment.jwt"
+
+The response mode "fragment.jwt" causes the authorization server to send the authorization response as HTTP redirect to the redirect URI of the client. The authorization server adds the parameter `response` containing the JWT as defined in (#jwt-response). to the fragment component of the redirect URI using the "application/x-www-form-urlencoded" format.
+
+This is an example response (line breaks for display purposes only): 
+
+```
+HTTP/1.1 302 Found
+Location: https://client.example.com/cb#
+response=eyJraWQiOiJsYWViIiwiYWxnIjoiRVMyNTYifQ.eyAgImlzcyI6ICJodHRwczovL2FjY291
+bnRzLmV4YW1wbGUuY29tIiwgICJhdWQiOiAiczZCaGRSa3F0MyIsICAiZXhwIjogMTMxMTI4MTk3MCwg
+ICJhY2Nlc3NfdG9rZW4iOiAiMllvdG5GWkZFanIxekNzaWNNV3BBQSIsICAic3RhdGUiOiAiUzhOSjd1
+cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2SDlqc1luaTlkTUFKdyIsICAidG9rZW5fdHlwZSI6ICJiZWFy
+ZXIiLCAgImV4cGlyZXNfaW4iOiAzNjAwLCAgInNjb3BlIjogImV4YW1wbGUifQ.g_96IM2t_6Dazm1Jp
+b2gbO2EXe5IKTw2bYS7l9Y1RI8HbNPYN5EdNjxcWeL5LTQaUAZ2PtJoHbTdjMvNa3xbVg
+```
+
+### Response Mode "form_post.jwt"
+
+The response mode "form_post.jwt" uses the technique described in [@!OIFP] to convey the JWT to the client. The `response` parameter containing the JWT is encoded as HTML form value that is auto-submitted in the User Agent, and thus is transmitted via the HTTP POST method to the Client, with the result parameters being encoded in the body using the "application/x-www-form-urlencoded" format.
+
+This is an example response from the authorization server to the user agent (line breaks for display purposes only), 
+
+```
+HTTP/1.1 200 OK
+Content-Type: text/html;charset=UTF-8
+Cache-Control: no-cache, no-store
+Pragma: no-cache
+
+<html>
+ <head><title>Submit This Form</title></head>
+ <body onload="javascript:document.forms[0].submit()">
+  <form method="post" action="https://client.example.com/cb">
+    <input type="hidden" name="response"
+     value="eyJraWQiOiJsYWViIiwiYWxnIjoiRVMyNTYifQ.eyAgImlzcyI6ICJodHRw
+     czovL2FjY291bnRzLmV4YW1wbGUuY29tIiwgICJhdWQiOiAiczZCaGRSa3F0MyIsIC
+     AiZXhwIjogMTMxMTI4MTk3MCwgICJhY2Nlc3NfdG9rZW4iOiAiMllvdG5GWkZFanIx
+     ekNzaWNNV3BBQSIsICAic3RhdGUiOiAiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdT
+     ZwVXN2SDlqc1luaTlkTUFKdyIsICAidG9rZW5fdHlwZSI6ICJiZWFyZXIiLCAgImV4
+     cGlyZXNfaW4iOiAzNjAwLCAgInNjb3BlIjogImV4YW1wbGUifQ.g_96IM2t_6Dazm1
+     Jpb2gbO2EXe5IKTw2bYS7l9Y1RI8HbNPYN5EdNjxcWeL5LTQaUAZ2PtJoHbTdjMvNa
+     3xbVg"/>
+    </form>
+   </body>
+  </html>  
+```
+which results in the following POST request to the client's redirect URI.
+
+```
+POST /cb HTTP/1.1
+Host: client.example.org
+Content-Type: application/x-www-form-urlencoded
+
+response=eyJraWQiOiJsYWViIiwiYWxnIjoiRVMyNTYifQ.eyAgImlzcyI6ICJodHRw
+czovL2FjY291bnRzLmV4YW1wbGUuY29tIiwgICJhdWQiOiAiczZCaGRSa3F0MyIsICAi
+ZXhwIjogMTMxMTI4MTk3MCwgICJhY2Nlc3NfdG9rZW4iOiAiMllvdG5GWkZFanIxekNz
+aWNNV3BBQSIsICAic3RhdGUiOiAiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2
+SDlqc1luaTlkTUFKdyIsICAidG9rZW5fdHlwZSI6ICJiZWFyZXIiLCAgImV4cGlyZXNf
+aW4iOiAzNjAwLCAgInNjb3BlIjogImV4YW1wbGUifQ.g_96IM2t_6Dazm1Jpb2gbO2EX
+e5IKTw2bYS7l9Y1RI8HbNPYN5EdNjxcWeL5LTQaUAZ2PtJoHbTdjMvNa3xbVg
+```  
+    
+### Response Mode "jwt"
+
+The response mode "jwt" is a shortcut and indicates the default redirect encoding (query, fragment) for the requested response type. The default for response type "code" is "query.jwt" whereas the default for "token" and the response types defined in [@!OIDM], except "none", is "fragment.jwt".
+
+## Processing rules
+
+Assumption: the client remembers the authorization server to which it sent the authorization request and binds this information to the user agent.
+
+The client MUST process the JWT secured response as follows:
+
+1. (OPTIONAL) The client decrypts the JWT using the default key for the respective issuer or, if applicable, determined by the `kid` JWT header parameter. The key might be a private key, where the corresponding public key is registered with the expected issuer of the response ("use":"enc" via the client's metadata `jwks` or `jwks_uri`) or a key derived from its client secret (see (#signing-and-encryption)). 
+1. The client obtains the `iss` element from the JWT and checks whether its value is well known and identifies the expected issuer of the authorization process in examination. If the check fails, the client MUST abort processing and refuse the response.
+1. The client obtains the `aud` element from the JWT and checks whether it matches the client id the client used to identify itself in the corresponding authorization request. If the check fails, the client MUST abort processing and refuse the response.
+1. The client checks the JWT's `exp` element to determine if the JWT is still valid. If the check fails, the client MUST abort processing and refuse the response. 
+1. The client MUST check the signature of the JWT according to [@!RFC7515] and the algorithm `none` (`"alg":"none"`) MUST NOT be accepted. If the check fails, the client MUST abort processing and refuse the response.
+
+The client will perform further checks, e.g. for CSRF detection, which are out of scope of this specification. Please see [@RFC9700] for more security recommendations.
+
+Note: The way the client obtains the keys for verifying the JWT's signature (step 5) is out of scope of this document. Established mechanism such as [@OIDD] or [@RFC8414] SHOULD be utilized.
+
+The client MUST NOT process the grant type specific authorization response parameters before all checks succeed. 
+
+# Client Metadata {#client-metadata}
+
+The Dynamic Client Registration Protocol [@RFC7591] defines an API
+for dynamically registering OAuth 2.0 client metadata with authorization servers.
+The metadata defined by [@RFC7591], and registered extensions to it,
+also imply a general data model for clients that is useful for authorization server implementations
+even when the Dynamic Client Registration Protocol isn't in play.
+Such implementations will typically have some sort of user interface available for managing client configuration.
+
+The following client metadata parameters are introduced by this specification:
+
+`authorization_signed_response_alg`
+:   The JWS [@!RFC7515] `alg` algorithm REQUIRED for signing authorization responses. If this is specified, the response will be signed using JWS and the configured algorithm. If unspecified, the default algorithm to use for signing authorization responses is `RS256`. The algorithm `none` is not allowed.
+
+`authorization_encrypted_response_alg`
+:   The JWE [@!RFC7516] `alg` algorithm REQUIRED for encrypting authorization responses.  If both signing and encryption are requested, the response will be signed then encrypted, with the result being a Nested JWT, as defined in JWT [@!RFC7519].  The default, if omitted, is that no encryption is performed.
+
+`authorization_encrypted_response_enc`
+:   The JWE [@!RFC7516] `enc` algorithm REQUIRED for encrypting authorization responses.  If `authorization_encrypted_response_alg` is specified, the default for this value is `A128CBC-HS256`.  When `authorization_encrypted_response_enc` is included, `authorization_encrypted_response_alg` MUST also be provided.
+
+The `jwks_uri` or `jwks` metadata parameters can be used by clients to register their public encryption keys.
+
+# Authorization Server Metadata {#as-metadata}
+
+Authorization servers SHOULD publish the supported algorithms for signing and encrypting the JWT of an authorization response by utilizing OAuth 2.0 Authorization Server Metadata [@RFC8414] parameters.
+
+The following parameters are introduced by this specification:
+
+`authorization_signing_alg_values_supported`
+:   OPTIONAL.  A JSON array containing a list of the JWS [@!RFC7515] signing algorithms (`alg` values) supported by the authorization endpoint to sign the response.
+
+`authorization_encryption_alg_values_supported`
+:   OPTIONAL.  A JSON array containing a list of the JWE [@!RFC7516] encryption algorithms (`alg` values) supported by the authorization endpoint to encrypt the response.
+
+`authorization_encryption_enc_values_supported`
+:   OPTIONAL.  A JSON array containing a list of the JWE [@!RFC7516] encryption algorithms (`enc` values)  supported by the authorization endpoint to encrypt the response.
+
+Authorization servers SHOULD publish the supported response mode values utilizing the parameter `response_modes_supported` as defined in [@RFC8414]. This document introduces the following possible values:
+
+*  `query.jwt`
+*  `fragment.jwt`
+*  `form_post.jwt`
+*  `jwt`
+
+# Security Considerations
+
+As JARM is used as a component in OAuth, many of the security considerations listed in OAuth 2.0 Security Best Current Practice [@RFC9700] apply. In addition, for the mechanisms described in this document, the following security considerations apply.
+
+## DoS using specially crafted JWTs
+JWTs could be crafted to have an issuer that resolves to a JWK set URL with
+huge content, or is delivered very slowly, consuming server networking
+bandwidth and compute capacity. The resolved JWK set URL could also be used to
+DDoS targets on the web.
+
+The client therefore MUST first check that the issuer of the JWT is well-known 
+and expected for the particular authorization response before it uses this data 
+to obtain the key needed to check the JWT's signature.  
+
+## Protocol Run Integrity
+An OAuth protocol run is made of many distinct message exchanges between the client and server
+to complete the issuance of access and refresh tokens. Even if every message itself is integrity
+protected, it is still conceivable that one or more of the messages are exchanged with another
+message created for a different protocol run. The leakage and reuse of encrypted messages in
+(#code-leakage) is an example of such problems. To mitigate this problem, it is considered good
+practice to implement additional protection provided by PKCE [@RFC7636]
+as described in [@RFC9700].
+
+## Mix-Up
+Mix-up is an attack on scenarios where an OAuth client interacts with
+multiple authorization servers. The goal of the attack is to obtain an
+authorization code or an access token by tricking the client into
+sending those credentials to the attacker instead of using them at
+the respective endpoint at the authorization/resource server.
+   
+The JWT secured response mode enables clients to detect this attack by providing an identification of the sender (`iss`) and the intended audience of the authorization response (`aud`). 
+
+## Code Leakage {#code-leakage}
+Authorization servers MAY encrypt the authorization response therewith providing a means to prevent leakage of authorization codes in the user agent (e.g. during transmission, in browser history or via referrer headers). 
+Note, however, that the entire response is then potentially subject to leakage. An encrypted response doesn't remove the need for additional protections provided by mechanisms such as PKCE [@RFC7636].
+
+# Privacy Considerations
+
+JARM only defines an alternative way of encoding the authorization response message and therefore does not materially impact the privacy considerations
+of OAuth 2.0, which is a complex and flexible framework with broad-ranging privacy implications. 
+
+The content of a conventional authorization response message (e.g., `code` and `state`) does not typically convey personally identifiable information (PII). However, using encrypted JARM may improve privacy by reducing the potential for inadvertent information disclosure in cases where the authorization response might contain PII (such as other response types or extensions).
+
+# IANA Considerations
+## OAuth Dynamic Client Registration Metadata Registration
+This specification requests registration of the following client metadata definitions in the IANA "OAuth Dynamic Client Registration Metadata" registry established by [@RFC7591]:
+
+### Registry Contents
+
+* Client Metadata Name: `authorization_signed_response_alg`
+* Client Metadata Description: String value indicating the client's desired authorization response signing algorithm.
+* Change Controller: IESG
+* Specification Document(s): (#client-metadata) of this specification
+* Client Metadata Name: `authorization_encrypted_response_alg`
+* Client Metadata Description: String value specifying the desired authorization response encryption algorithm (alg value).
+* Change Controller: IESG
+* Specification Document(s): (#client-metadata) of this specification
+* Client Metadata Name: `authorization_encrypted_response_enc`
+* Client Metadata Description: String value specifying the desired authorization response encryption algorithm (enc value).
+* Change Controller: IESG
+* Specification Document(s): (#client-metadata) of this specification
+
+## OAuth Authorization Server Metadata Registration
+This specification requests registration of the following value in the IANA "OAuth Authorization Server Metadata" registry established by [@RFC8414].
+
+### Registry Contents
+
+* Metadata Name: `authorization_signing_alg_values_supported`
+* Metadata Description: JSON array containing a list of algorithms supported by the authorization server for authorization response signing.
+* Change Controller: IESG
+* Specification Document(s): (#as-metadata) of this specification
+* Metadata Name: `authorization_encryption_alg_values_supported`
+* Metadata Description: JSON array containing a list of algorithms supported by the authorization server for authorization response encryption (alg value).
+* Change Controller: IESG
+* Specification Document(s): (#as-metadata) of this specification
+* Metadata Name: `authorization_encryption_enc_values_supported`
+* Metadata Description: JSON array containing a list of algorithms supported by the authorization server for authorization response encryption (enc value).
+* Change Controller: IESG
+* Specification Document(s): (#as-metadata) of this specification
+
+{backmatter}
+
+<reference anchor="OIDC" target="http://openid.net/specs/openid-connect-core-1_0.html">
+  <front>
+    <title>OpenID Connect Core 1.0 incorporating errata set 1</title>
+    <author initials="N." surname="Sakimura" fullname="Nat Sakimura">
+      <organization>NRI</organization>
+    </author>
+    <author initials="J." surname="Bradley" fullname="John Bradley">
+      <organization>Ping Identity</organization>
+    </author>
+    <author initials="M." surname="Jones" fullname="Mike Jones">
+      <organization>Microsoft</organization>
+    </author>
+    <author initials="B." surname="de Medeiros" fullname="Breno de Medeiros">
+      <organization>Google</organization>
+    </author>
+    <author initials="C." surname="Mortimore" fullname="Chuck Mortimore">
+      <organization>Salesforce</organization>
+    </author>
+   <date day="8" month="Nov" year="2014"/>
+  </front>
+</reference>
+
+<reference anchor="OIDD" target="https://openid.net/specs/openid-connect-discovery-1_0.html">
+  <front>
+    <title>OpenID Connect Discovery 1.0 incorporating errata set 1</title>
+    <author initials="N." surname="Sakimura" fullname="Nat Sakimura">
+      <organization>NRI</organization>
+    </author>
+    <author initials="J." surname="Bradley" fullname="John Bradley">
+      <organization>Ping Identity</organization>
+    </author>
+    <author initials="M." surname="Jones" fullname="Mike Jones">
+      <organization>Microsoft</organization>
+    </author>
+    <author initials="E." surname="Jay" fullname="Edmund Jay">
+      <organization>Illumila</organization>
+    </author>
+    <date day="8" month="Nov" year="2014"/>
+  </front>
+</reference>
+
+<reference anchor="OIFP" target="https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html">
+  <front>
+    <title>OAuth 2.0 Form Post Response Mode</title>
+    <author initials="M." surname="Jones" fullname="Mike Jones">
+      <organization>Microsoft</organization>
+    </author>
+    <author initials="B." surname="Campbell" fullname="Brian Campbell">
+      <organization>Illumila</organization>
+    </author>
+    <date day="27" month="April" year="2015"/>
+  </front>
+</reference>
+
+<reference anchor="OIDM" target="http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html">
+<front>
+<title>OAuth 2.0 Multiple Response Type Encoding Practices</title>
+<author fullname="Breno de Medeiros" initials="B." role="editor" surname="de Medeiros">
+<organization abbrev="Google">Google</organization>
+</author>
+<author fullname="Marius Scurtescu" initials="M." surname="Scurtescu">
+<organization abbrev="Google">Google</organization>
+</author>
+<author fullname="Paul Tarjan" initials="P." surname="Tarjan">
+<organization abbrev="Facebook"> Facebook</organization>
+</author>
+<author fullname="Michael B. Jones" initials="M.B." surname="Jones">
+<organization abbrev="Microsoft">Microsoft</organization>
+</author>
+<date day="25" month="February" year="2014" />
+</front>
+</reference>
+
+<reference anchor="OISM" target="http://openid.net/specs/openid-connect-session-1_0.html">
+<front>
+  <title>OpenID Connect Session Management 1.0</title>
+  <author fullname="Breno de Medeiros" initials="B." surname="de Medeiros">
+    <organization>Google</organization>
+  </author>
+  <author fullname="Naveen Agarwal" initials="N." surname="Agarwal">
+    <organization>Microsoft</organization>
+  </author>
+  <author fullname="Nat Sakimura" initials="N." surname="Sakimura">
+    <organization abbrev="NAT.Consulting">NAT.Consulting</organization>
+  </author>
+  <author fullname="John Bradley" initials="J." surname="Bradley">
+    <organization abbrev="Yubico">Yubico</organization>
+  </author>
+  <author fullname="Michael B. Jones" initials="M.B." surname="Jones">
+    <organization abbrev="Microsoft">Microsoft</organization>
+  </author>
+  <date day="14" month="March" year="2022" />
+</front>
+</reference>
+
+# Acknowledgements
+
+The following people contributed to this document:
+
+* Torsten Lodderstedt (SPRIND), Editor
+* Brian Campbell (Ping Identity), Co-editor
+* Nat Sakimura (NAT Consulting LLC) -- Chair
+* Dave Tonge (Moneyhub) -- Chair
+* Joseph Heenan (Authlete)
+* Ralph Bragg (Raidiam)
+* Vladimir Dzhuvinov (Connect2ID)
+* Michael Schwartz (Gluu)
+* Filip Skokan (Auth0|Okta)
+
+# Notices
+
+Copyright (c) 2025 The OpenID Foundation.
+
+The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
+or other interested party a non-exclusive, royalty free, worldwide copyright license to
+reproduce, prepare derivative works from, distribute, perform and display, this
+Implementers Draft, Final Specification, or Final Specification Incorporating Errata
+Corrections solely for the purposes of (i) developing specifications, and (ii)
+implementing Implementers Drafts, Final Specifications, and Final Specification
+Incorporating Errata Corrections based on such documents, provided that attribution
+be made to the OIDF as the source of the material, but that such attribution does not
+indicate an endorsement by the OIDF.
+
+The technology described in this specification was made available from contributions
+from various sources, including members of the OpenID Foundation and others.
+Although the OpenID Foundation has taken steps to help ensure that the technology
+is available for distribution, it takes no position regarding the validity or scope of any
+intellectual property or other rights that might be claimed to pertain to the
+implementation or use of the technology described in this specification or the extent
+to which any license under such rights might or might not be available; neither does it
+represent that it has made any independent effort to identify any such rights. The
+OpenID Foundation and the contributors to this specification make no (and hereby
+expressly disclaim any) warranties (express, implied, or otherwise), including implied
+warranties of merchantability, non-infringement, fitness for a particular purpose, or
+title, related to this specification, and the entire risk as to implementing this
+specification is assumed by the implementer. The OpenID Intellectual Property
+Rights policy (found at openid.net) requires contributors to offer a patent promise not
+to assert certain patent claims against other contributors and against implementers.
+OpenID invites any interested party to bring to its attention any copyrights, patents,
+patent applications, or other proprietary rights that may cover technology that may be
+required to practice this specification.
+
+# Document History
+
+[[ To be removed from the approved specification incorporating errata corrections ]]
+
+-05
+
+* Resolve JARM IANA registration review feedback
+* Update copyright notice
+* Update author and contributor associations
+* Update security topics reference to RFC970

--- a/sync/specs/oauth-v2-jarm-05.xml
+++ b/sync/specs/oauth-v2-jarm-05.xml
@@ -1,0 +1,514 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- name="GENERATOR" content="github.com/mmarkdown/mmark Mmark Markdown Processor - mmark.miek.nl" -->
+<rfc version="3" ipr="none" docName="oauth-v2-jarm-05" submissionType="IETF" category="std" xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude" indexInclude="true" consensus="true">
+
+<front>
+<title abbrev="OAuth JARM">JWT Secured Authorization Response Mode for OAuth 2.0 (JARM) - Draft 05 incorporating errata set 1</title><seriesInfo value="oauth-v2-jarm-05" status="standard" name="Internet-Draft"></seriesInfo>
+<author initials="T." surname="Lodderstedt" fullname="Torsten Lodderstedt"><organization>SPRIND</organization><address><postal><street></street>
+</postal><email>torsten@lodderstedt.net</email>
+</address></author><author initials="B." surname="Campbell" fullname="Brian Campbell"><organization>Ping Identity</organization><address><postal><street></street>
+</postal><email>bcampbell@pingidentity.com</email>
+</address></author><date/>
+<area>Internet</area>
+<workgroup>FAPI</workgroup>
+<keyword>security</keyword>
+<keyword>oauth2</keyword>
+
+</front>
+
+<middle>
+
+<section anchor="introduction"><name>Introduction</name>
+<t>This document defines a new JWT-based mode to encode OAuth authorization responses. Clients are enabled to request
+the transmission of the authorization response parameters along with additional data in JWT format.
+This mechanism enhances the security of the standard authorization response with support for signing and optional encryption of the response.
+A signed response provides message integrity, sender authentication, audience restriction, and protection from mix-up attacks. Encrypting the response provides confidentiality of the response parameter values.
+The JWT authorization response mode can be used in conjunction with any response type.</t>
+
+<section anchor="notational-conventions"><name>Notational Conventions</name>
+<t>The key words &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL
+NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;,
+&quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as
+described in BCP 14 <xref target="RFC2119"></xref> <xref target="RFC8174"></xref> when, and only when, they
+appear in all capitals, as shown here.</t>
+</section>
+
+<section anchor="terms-and-definitions"><name>Terms and definitions</name>
+<t>For the purpose of this document, the terms defined in <xref target="RFC6749"></xref> and <xref target="OIDC"></xref> apply.</t>
+</section>
+
+<section anchor="symbols-and-abbreviated-terms"><name>Symbols and Abbreviated terms</name>
+<t><strong>API</strong> – Application Programming Interface</t>
+<t><strong>CSRF</strong> - Cross Site Request Forgery</t>
+<t><strong>HTTP</strong> – Hyper Text Transfer Protocol</t>
+<t><strong>OIDF</strong> - OpenID Foundation</t>
+<t><strong>TLS</strong> – Transport Layer Security</t>
+</section>
+</section>
+
+<section anchor="jwt-based-response-mode"><name>JWT-based Response Mode</name>
+<t>This document defines a new JWT-based <xref target="RFC7519"></xref> mode to encode OAuth <xref target="RFC6749"></xref> authorization response parameters. All response parameters defined for a given response type are conveyed in a JWT along with additional claims used to further protect the transmission. Since there are different techniques to encode the JWT itself in the response to the client, namely query URI parameter, fragment component and form post, this document defines a set of response mode values in accordance with <xref target="OIDM"></xref> corresponding to these techniques.</t>
+
+<section anchor="jwt-response"><name>The JWT Response Document</name>
+<t>The JWT always contains the following data utilized to secure the transmission:</t>
+
+<ul spacing="compact">
+<li><tt>iss</tt> - the issuer URL of the authorization server that created the response</li>
+<li><tt>aud</tt> - the client_id of the client the response is intended for</li>
+<li><tt>exp</tt> - expiration of the JWT. A maximum JWT lifetime of 10 minutes is RECOMMENDED.</li>
+</ul>
+<t>The JWT MUST furthermore contain the authorization endpoint response parameters as defined for the particular response types, even in case of an error response. Authorization endpoint response parameter names and string values are included as JSON strings and numerical values (e.g., <tt>expires_in</tt> value) are included as JSON numbers. This pattern is applicable to all response types including those defined in <xref target="OIDM"></xref>. The following subsection illustrates the pattern for the response type &quot;code&quot;.</t>
+<t>Note: Additional authorization endpoint response parameters defined by extensions, e.g. <tt>session_state</tt> as defined in <xref target="OISM"></xref>, will also be added to the JWT.</t>
+<t>The JWT response document MAY contain further element, e.g. the claims defined in <xref target="RFC7519"></xref>. Implementation SHOULD adhere to the respective processing rules and ignore unrecognized elements.</t>
+
+<section anchor="example-response-type-code"><name>Example Response Type &quot;code&quot;</name>
+<t>For the grant type authorization &quot;code&quot; the JWT contains the response parameters as defined in <xref target="RFC6749"></xref>, sections 4.1.2:</t>
+
+<ul spacing="compact">
+<li><tt>code</tt> - the authorization code</li>
+<li><tt>state</tt> - the state value as sent by the client in the authorization request, if the client included a <tt>state</tt> parameter</li>
+</ul>
+<t>The following example shows the JWT claims for a successful &quot;code&quot; authorization response:</t>
+
+<artwork>{  
+   &quot;iss&quot;:&quot;https://accounts.example.com&quot;,
+   &quot;aud&quot;:&quot;s6BhdRkqt3&quot;,
+   &quot;exp&quot;:1311281970,
+   &quot;code&quot;:&quot;PyyFaux2o7Q0YfXBU32jhw.5FXSQpvr8akv9CeRDSd0QA&quot;,  
+   &quot;state&quot;:&quot;S8NJ7uqk5fY4EjNvP_G_FtyJu6pUsvH9jsYni9dMAJw&quot;
+}
+</artwork>
+<t>In case of an error response, the JWT contains the error response parameters as defined in <xref target="RFC6749"></xref>, sections 4.1.2.1:</t>
+
+<ul spacing="compact">
+<li><tt>error</tt> - the error code</li>
+<li><tt>error_description</tt> (OPTIONAL) - a human readable description of the error</li>
+<li><tt>error_uri</tt> (OPTIONAL) - a URI identifying a human-readable web page with information about the error</li>
+<li><tt>state</tt> - the state value as sent by the client in the authorization request (if applicable)</li>
+</ul>
+<t>The following example shows the JWT payload for such an error response:</t>
+
+<artwork>{
+   &quot;iss&quot;:&quot;https://accounts.example.com&quot;,
+   &quot;aud&quot;:&quot;s6BhdRkqt3&quot;,
+   &quot;exp&quot;:1311281970,
+   &quot;error&quot;:&quot;access_denied&quot;,
+   &quot;state&quot;:&quot;S8NJ7uqk5fY4EjNvP_G_FtyJu6pUsvH9jsYni9dMAJw&quot;
+}
+</artwork>
+</section>
+</section>
+
+<section anchor="signing-and-encryption"><name>Signing and Encryption</name>
+<t>The JWT is either signed, or signed and encrypted. If the JWT is both signed and encrypted, the JSON document will be signed then encrypted, with the result being a Nested JWT, as defined in <xref target="RFC7519"></xref>.</t>
+<t>The authorization server determines what algorithm to employ to secure the JWT for a particular authorization response. This decision can be based on registered metadata parameters for the client as defined by this document (see <xref target="client-metadata"></xref>).</t>
+<t>For guidance on key management in general and especially on use of symmetric algorithms for signing and encrypting based on client secrets see section 10 of <xref target="OIDC"></xref>.</t>
+</section>
+
+<section anchor="response-encoding"><name>Response Encoding</name>
+<t>This document defines the following response mode values:</t>
+
+<ul spacing="compact">
+<li><tt>query.jwt</tt></li>
+<li><tt>fragment.jwt</tt></li>
+<li><tt>form_post.jwt</tt></li>
+<li><tt>jwt</tt></li>
+</ul>
+
+<section anchor="response-mode-query-jwt"><name>Response Mode &quot;query.jwt&quot;</name>
+<t>The response mode &quot;query.jwt&quot; causes the authorization server to send the authorization response as HTTP redirect to the redirect URI of the client. The authorization server adds the parameter <tt>response</tt> containing the JWT as defined in <xref target="jwt-response"></xref>. to the query component of the redirect URI using the &quot;application/x-www-form-urlencoded&quot; format.</t>
+<t>This is an example response (line breaks for display purposes only):</t>
+
+<artwork>HTTP/1.1 302 Found
+Location: https://client.example.com/cb?
+response=eyJraWQiOiJsYWViIiwiYWxnIjoiRVMyNTYifQ.eyAgImlzcyI6ICJodHRwczovL2FjY291
+bnRzLmV4YW1wbGUuY29tIiwgICJhdWQiOiAiczZCaGRSa3F0MyIsICAiZXhwIjogMTMxMTI4MTk3MCwg
+ICJjb2RlIjogIlB5eUZhdXgybzdRMFlmWEJVMzJqaHcuNUZYU1FwdnI4YWt2OUNlUkRTZDBRQSIsICAi
+c3RhdGUiOiAiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2SDlqc1luaTlkTUFKdyJ9.4VdtknV
+Z9zFYDVLagJpVBD436bjPMcSgOaPDPFgTEkNyCs2uIHYJ2XML6d2w1AUsm5GBG77DBisZNhLWfug6dA
+</artwork>
+<t>Note: &quot;query.jwt&quot; MUST NOT be used in conjunction with response types that contain &quot;token&quot; or &quot;id_token&quot; unless the response JWT is encrypted to prevent token leakage in the URL.</t>
+</section>
+
+<section anchor="response-mode-fragment-jwt"><name>Response Mode &quot;fragment.jwt&quot;</name>
+<t>The response mode &quot;fragment.jwt&quot; causes the authorization server to send the authorization response as HTTP redirect to the redirect URI of the client. The authorization server adds the parameter <tt>response</tt> containing the JWT as defined in <xref target="jwt-response"></xref>. to the fragment component of the redirect URI using the &quot;application/x-www-form-urlencoded&quot; format.</t>
+<t>This is an example response (line breaks for display purposes only):</t>
+
+<artwork>HTTP/1.1 302 Found
+Location: https://client.example.com/cb#
+response=eyJraWQiOiJsYWViIiwiYWxnIjoiRVMyNTYifQ.eyAgImlzcyI6ICJodHRwczovL2FjY291
+bnRzLmV4YW1wbGUuY29tIiwgICJhdWQiOiAiczZCaGRSa3F0MyIsICAiZXhwIjogMTMxMTI4MTk3MCwg
+ICJhY2Nlc3NfdG9rZW4iOiAiMllvdG5GWkZFanIxekNzaWNNV3BBQSIsICAic3RhdGUiOiAiUzhOSjd1
+cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2SDlqc1luaTlkTUFKdyIsICAidG9rZW5fdHlwZSI6ICJiZWFy
+ZXIiLCAgImV4cGlyZXNfaW4iOiAzNjAwLCAgInNjb3BlIjogImV4YW1wbGUifQ.g_96IM2t_6Dazm1Jp
+b2gbO2EXe5IKTw2bYS7l9Y1RI8HbNPYN5EdNjxcWeL5LTQaUAZ2PtJoHbTdjMvNa3xbVg
+</artwork>
+</section>
+
+<section anchor="response-mode-form-post-jwt"><name>Response Mode &quot;form_post.jwt&quot;</name>
+<t>The response mode &quot;form_post.jwt&quot; uses the technique described in <xref target="OIFP"></xref> to convey the JWT to the client. The <tt>response</tt> parameter containing the JWT is encoded as HTML form value that is auto-submitted in the User Agent, and thus is transmitted via the HTTP POST method to the Client, with the result parameters being encoded in the body using the &quot;application/x-www-form-urlencoded&quot; format.</t>
+<t>This is an example response from the authorization server to the user agent (line breaks for display purposes only),</t>
+
+<artwork>HTTP/1.1 200 OK
+Content-Type: text/html;charset=UTF-8
+Cache-Control: no-cache, no-store
+Pragma: no-cache
+
+&lt;html&gt;
+ &lt;head&gt;&lt;title&gt;Submit This Form&lt;/title&gt;&lt;/head&gt;
+ &lt;body onload=&quot;javascript:document.forms[0].submit()&quot;&gt;
+  &lt;form method=&quot;post&quot; action=&quot;https://client.example.com/cb&quot;&gt;
+    &lt;input type=&quot;hidden&quot; name=&quot;response&quot;
+     value=&quot;eyJraWQiOiJsYWViIiwiYWxnIjoiRVMyNTYifQ.eyAgImlzcyI6ICJodHRw
+     czovL2FjY291bnRzLmV4YW1wbGUuY29tIiwgICJhdWQiOiAiczZCaGRSa3F0MyIsIC
+     AiZXhwIjogMTMxMTI4MTk3MCwgICJhY2Nlc3NfdG9rZW4iOiAiMllvdG5GWkZFanIx
+     ekNzaWNNV3BBQSIsICAic3RhdGUiOiAiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdT
+     ZwVXN2SDlqc1luaTlkTUFKdyIsICAidG9rZW5fdHlwZSI6ICJiZWFyZXIiLCAgImV4
+     cGlyZXNfaW4iOiAzNjAwLCAgInNjb3BlIjogImV4YW1wbGUifQ.g_96IM2t_6Dazm1
+     Jpb2gbO2EXe5IKTw2bYS7l9Y1RI8HbNPYN5EdNjxcWeL5LTQaUAZ2PtJoHbTdjMvNa
+     3xbVg&quot;/&gt;
+    &lt;/form&gt;
+   &lt;/body&gt;
+  &lt;/html&gt;  
+</artwork>
+<t>which results in the following POST request to the client's redirect URI.</t>
+
+<artwork>POST /cb HTTP/1.1
+Host: client.example.org
+Content-Type: application/x-www-form-urlencoded
+
+response=eyJraWQiOiJsYWViIiwiYWxnIjoiRVMyNTYifQ.eyAgImlzcyI6ICJodHRw
+czovL2FjY291bnRzLmV4YW1wbGUuY29tIiwgICJhdWQiOiAiczZCaGRSa3F0MyIsICAi
+ZXhwIjogMTMxMTI4MTk3MCwgICJhY2Nlc3NfdG9rZW4iOiAiMllvdG5GWkZFanIxekNz
+aWNNV3BBQSIsICAic3RhdGUiOiAiUzhOSjd1cWs1Zlk0RWpOdlBfR19GdHlKdTZwVXN2
+SDlqc1luaTlkTUFKdyIsICAidG9rZW5fdHlwZSI6ICJiZWFyZXIiLCAgImV4cGlyZXNf
+aW4iOiAzNjAwLCAgInNjb3BlIjogImV4YW1wbGUifQ.g_96IM2t_6Dazm1Jpb2gbO2EX
+e5IKTw2bYS7l9Y1RI8HbNPYN5EdNjxcWeL5LTQaUAZ2PtJoHbTdjMvNa3xbVg
+</artwork>
+</section>
+
+<section anchor="response-mode-jwt"><name>Response Mode &quot;jwt&quot;</name>
+<t>The response mode &quot;jwt&quot; is a shortcut and indicates the default redirect encoding (query, fragment) for the requested response type. The default for response type &quot;code&quot; is &quot;query.jwt&quot; whereas the default for &quot;token&quot; and the response types defined in <xref target="OIDM"></xref>, except &quot;none&quot;, is &quot;fragment.jwt&quot;.</t>
+</section>
+</section>
+
+<section anchor="processing-rules"><name>Processing rules</name>
+<t>Assumption: the client remembers the authorization server to which it sent the authorization request and binds this information to the user agent.</t>
+<t>The client MUST process the JWT secured response as follows:</t>
+
+<ol spacing="compact">
+<li>(OPTIONAL) The client decrypts the JWT using the default key for the respective issuer or, if applicable, determined by the <tt>kid</tt> JWT header parameter. The key might be a private key, where the corresponding public key is registered with the expected issuer of the response (&quot;use&quot;:&quot;enc&quot; via the client's metadata <tt>jwks</tt> or <tt>jwks_uri</tt>) or a key derived from its client secret (see <xref target="signing-and-encryption"></xref>).</li>
+<li>The client obtains the <tt>iss</tt> element from the JWT and checks whether its value is well known and identifies the expected issuer of the authorization process in examination. If the check fails, the client MUST abort processing and refuse the response.</li>
+<li>The client obtains the <tt>aud</tt> element from the JWT and checks whether it matches the client id the client used to identify itself in the corresponding authorization request. If the check fails, the client MUST abort processing and refuse the response.</li>
+<li>The client checks the JWT's <tt>exp</tt> element to determine if the JWT is still valid. If the check fails, the client MUST abort processing and refuse the response.</li>
+<li>The client MUST check the signature of the JWT according to <xref target="RFC7515"></xref> and the algorithm <tt>none</tt> (<tt>&quot;alg&quot;:&quot;none&quot;</tt>) MUST NOT be accepted. If the check fails, the client MUST abort processing and refuse the response.</li>
+</ol>
+<t>The client will perform further checks, e.g. for CSRF detection, which are out of scope of this specification. Please see <xref target="RFC9700"></xref> for more security recommendations.</t>
+<t>Note: The way the client obtains the keys for verifying the JWT's signature (step 5) is out of scope of this document. Established mechanism such as <xref target="OIDD"></xref> or <xref target="RFC8414"></xref> SHOULD be utilized.</t>
+<t>The client MUST NOT process the grant type specific authorization response parameters before all checks succeed.</t>
+</section>
+</section>
+
+<section anchor="client-metadata"><name>Client Metadata</name>
+<t>The Dynamic Client Registration Protocol <xref target="RFC7591"></xref> defines an API
+for dynamically registering OAuth 2.0 client metadata with authorization servers.
+The metadata defined by <xref target="RFC7591"></xref>, and registered extensions to it,
+also imply a general data model for clients that is useful for authorization server implementations
+even when the Dynamic Client Registration Protocol isn't in play.
+Such implementations will typically have some sort of user interface available for managing client configuration.</t>
+<t>The following client metadata parameters are introduced by this specification:</t>
+
+<dl spacing="compact">
+<dt><tt>authorization_signed_response_alg</tt></dt>
+<dd>The JWS <xref target="RFC7515"></xref> <tt>alg</tt> algorithm REQUIRED for signing authorization responses. If this is specified, the response will be signed using JWS and the configured algorithm. If unspecified, the default algorithm to use for signing authorization responses is <tt>RS256</tt>. The algorithm <tt>none</tt> is not allowed.</dd>
+<dt><tt>authorization_encrypted_response_alg</tt></dt>
+<dd>The JWE <xref target="RFC7516"></xref> <tt>alg</tt> algorithm REQUIRED for encrypting authorization responses.  If both signing and encryption are requested, the response will be signed then encrypted, with the result being a Nested JWT, as defined in JWT <xref target="RFC7519"></xref>.  The default, if omitted, is that no encryption is performed.</dd>
+<dt><tt>authorization_encrypted_response_enc</tt></dt>
+<dd>The JWE <xref target="RFC7516"></xref> <tt>enc</tt> algorithm REQUIRED for encrypting authorization responses.  If <tt>authorization_encrypted_response_alg</tt> is specified, the default for this value is <tt>A128CBC-HS256</tt>.  When <tt>authorization_encrypted_response_enc</tt> is included, <tt>authorization_encrypted_response_alg</tt> MUST also be provided.</dd>
+</dl>
+<t>The <tt>jwks_uri</tt> or <tt>jwks</tt> metadata parameters can be used by clients to register their public encryption keys.</t>
+</section>
+
+<section anchor="as-metadata"><name>Authorization Server Metadata</name>
+<t>Authorization servers SHOULD publish the supported algorithms for signing and encrypting the JWT of an authorization response by utilizing OAuth 2.0 Authorization Server Metadata <xref target="RFC8414"></xref> parameters.</t>
+<t>The following parameters are introduced by this specification:</t>
+
+<dl spacing="compact">
+<dt><tt>authorization_signing_alg_values_supported</tt></dt>
+<dd>OPTIONAL.  A JSON array containing a list of the JWS <xref target="RFC7515"></xref> signing algorithms (<tt>alg</tt> values) supported by the authorization endpoint to sign the response.</dd>
+<dt><tt>authorization_encryption_alg_values_supported</tt></dt>
+<dd>OPTIONAL.  A JSON array containing a list of the JWE <xref target="RFC7516"></xref> encryption algorithms (<tt>alg</tt> values) supported by the authorization endpoint to encrypt the response.</dd>
+<dt><tt>authorization_encryption_enc_values_supported</tt></dt>
+<dd>OPTIONAL.  A JSON array containing a list of the JWE <xref target="RFC7516"></xref> encryption algorithms (<tt>enc</tt> values)  supported by the authorization endpoint to encrypt the response.</dd>
+</dl>
+<t>Authorization servers SHOULD publish the supported response mode values utilizing the parameter <tt>response_modes_supported</tt> as defined in <xref target="RFC8414"></xref>. This document introduces the following possible values:</t>
+
+<ul spacing="compact">
+<li><tt>query.jwt</tt></li>
+<li><tt>fragment.jwt</tt></li>
+<li><tt>form_post.jwt</tt></li>
+<li><tt>jwt</tt></li>
+</ul>
+</section>
+
+<section anchor="security-considerations"><name>Security Considerations</name>
+<t>As JARM is used as a component in OAuth, many of the security considerations listed in OAuth 2.0 Security Best Current Practice <xref target="RFC9700"></xref> apply. In addition, for the mechanisms described in this document, the following security considerations apply.</t>
+
+<section anchor="dos-using-specially-crafted-jwts"><name>DoS using specially crafted JWTs</name>
+<t>JWTs could be crafted to have an issuer that resolves to a JWK set URL with
+huge content, or is delivered very slowly, consuming server networking
+bandwidth and compute capacity. The resolved JWK set URL could also be used to
+DDoS targets on the web.</t>
+<t>The client therefore MUST first check that the issuer of the JWT is well-known
+and expected for the particular authorization response before it uses this data
+to obtain the key needed to check the JWT's signature.</t>
+</section>
+
+<section anchor="protocol-run-integrity"><name>Protocol Run Integrity</name>
+<t>An OAuth protocol run is made of many distinct message exchanges between the client and server
+to complete the issuance of access and refresh tokens. Even if every message itself is integrity
+protected, it is still conceivable that one or more of the messages are exchanged with another
+message created for a different protocol run. The leakage and reuse of encrypted messages in
+<xref target="code-leakage"></xref> is an example of such problems. To mitigate this problem, it is considered good
+practice to implement additional protection provided by PKCE <xref target="RFC7636"></xref>
+as described in <xref target="RFC9700"></xref>.</t>
+</section>
+
+<section anchor="mix-up"><name>Mix-Up</name>
+<t>Mix-up is an attack on scenarios where an OAuth client interacts with
+multiple authorization servers. The goal of the attack is to obtain an
+authorization code or an access token by tricking the client into
+sending those credentials to the attacker instead of using them at
+the respective endpoint at the authorization/resource server.</t>
+<t>The JWT secured response mode enables clients to detect this attack by providing an identification of the sender (<tt>iss</tt>) and the intended audience of the authorization response (<tt>aud</tt>).</t>
+</section>
+
+<section anchor="code-leakage"><name>Code Leakage</name>
+<t>Authorization servers MAY encrypt the authorization response therewith providing a means to prevent leakage of authorization codes in the user agent (e.g. during transmission, in browser history or via referrer headers).
+Note, however, that the entire response is then potentially subject to leakage. An encrypted response doesn't remove the need for additional protections provided by mechanisms such as PKCE <xref target="RFC7636"></xref>.</t>
+</section>
+</section>
+
+<section anchor="privacy-considerations"><name>Privacy Considerations</name>
+<t>JARM only defines an alternative way of encoding the authorization response message and therefore does not materially impact the privacy considerations
+of OAuth 2.0, which is a complex and flexible framework with broad-ranging privacy implications.</t>
+<t>The content of a conventional authorization response message (e.g., <tt>code</tt> and <tt>state</tt>) does not typically convey personally identifiable information (PII). However, using encrypted JARM may improve privacy by reducing the potential for inadvertent information disclosure in cases where the authorization response might contain PII (such as other response types or extensions).</t>
+</section>
+
+<section anchor="iana-considerations"><name>IANA Considerations</name>
+
+<section anchor="oauth-dynamic-client-registration-metadata-registration"><name>OAuth Dynamic Client Registration Metadata Registration</name>
+<t>This specification requests registration of the following client metadata definitions in the IANA &quot;OAuth Dynamic Client Registration Metadata&quot; registry established by <xref target="RFC7591"></xref>:</t>
+
+<section anchor="registry-contents"><name>Registry Contents</name>
+
+<ul spacing="compact">
+<li>Client Metadata Name: <tt>authorization_signed_response_alg</tt></li>
+<li>Client Metadata Description: String value indicating the client's desired authorization response signing algorithm.</li>
+<li>Change Controller: IESG</li>
+<li>Specification Document(s): <xref target="client-metadata"></xref> of this specification</li>
+<li>Client Metadata Name: <tt>authorization_encrypted_response_alg</tt></li>
+<li>Client Metadata Description: String value specifying the desired authorization response encryption algorithm (alg value).</li>
+<li>Change Controller: IESG</li>
+<li>Specification Document(s): <xref target="client-metadata"></xref> of this specification</li>
+<li>Client Metadata Name: <tt>authorization_encrypted_response_enc</tt></li>
+<li>Client Metadata Description: String value specifying the desired authorization response encryption algorithm (enc value).</li>
+<li>Change Controller: IESG</li>
+<li>Specification Document(s): <xref target="client-metadata"></xref> of this specification</li>
+</ul>
+</section>
+</section>
+
+<section anchor="oauth-authorization-server-metadata-registration"><name>OAuth Authorization Server Metadata Registration</name>
+<t>This specification requests registration of the following value in the IANA &quot;OAuth Authorization Server Metadata&quot; registry established by <xref target="RFC8414"></xref>.</t>
+
+<section anchor="registry-contents-1"><name>Registry Contents</name>
+
+<ul spacing="compact">
+<li>Metadata Name: <tt>authorization_signing_alg_values_supported</tt></li>
+<li>Metadata Description: JSON array containing a list of algorithms supported by the authorization server for authorization response signing.</li>
+<li>Change Controller: IESG</li>
+<li>Specification Document(s): <xref target="as-metadata"></xref> of this specification</li>
+<li>Metadata Name: <tt>authorization_encryption_alg_values_supported</tt></li>
+<li>Metadata Description: JSON array containing a list of algorithms supported by the authorization server for authorization response encryption (alg value).</li>
+<li>Change Controller: IESG</li>
+<li>Specification Document(s): <xref target="as-metadata"></xref> of this specification</li>
+<li>Metadata Name: <tt>authorization_encryption_enc_values_supported</tt></li>
+<li>Metadata Description: JSON array containing a list of algorithms supported by the authorization server for authorization response encryption (enc value).</li>
+<li>Change Controller: IESG</li>
+<li>Specification Document(s): <xref target="as-metadata"></xref> of this specification</li>
+</ul>
+</section>
+</section>
+</section>
+
+</middle>
+
+<back>
+<references><name>Normative References</name>
+<reference anchor="OIDM" target="http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html">
+  <front>
+    <title>OAuth 2.0 Multiple Response Type Encoding Practices</title>
+    <author fullname="Breno de Medeiros" initials="B." surname="de Medeiros" role="editor">
+      <organization abbrev="Google">Google</organization>
+    </author>
+    <author fullname="Marius Scurtescu" initials="M." surname="Scurtescu">
+      <organization abbrev="Google">Google</organization>
+    </author>
+    <author fullname="Paul Tarjan" initials="P." surname="Tarjan">
+      <organization abbrev="Facebook"> Facebook</organization>
+    </author>
+    <author fullname="Michael B. Jones" initials="M.B." surname="Jones">
+      <organization abbrev="Microsoft">Microsoft</organization>
+    </author>
+    <date year="2014" month="February" day="25"></date>
+  </front>
+</reference>
+<reference anchor="OIFP" target="https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html">
+  <front>
+    <title>OAuth 2.0 Form Post Response Mode</title>
+    <author fullname="Mike Jones" initials="M." surname="Jones">
+      <organization>Microsoft</organization>
+    </author>
+    <author fullname="Brian Campbell" initials="B." surname="Campbell">
+      <organization>Illumila</organization>
+    </author>
+    <date year="2015" month="April" day="27"></date>
+  </front>
+</reference>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.6749.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7515.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7516.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7519.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
+</references>
+<references><name>Informative References</name>
+<reference anchor="OIDC" target="http://openid.net/specs/openid-connect-core-1_0.html">
+  <front>
+    <title>OpenID Connect Core 1.0 incorporating errata set 1</title>
+    <author fullname="Nat Sakimura" initials="N." surname="Sakimura">
+      <organization>NRI</organization>
+    </author>
+    <author fullname="John Bradley" initials="J." surname="Bradley">
+      <organization>Ping Identity</organization>
+    </author>
+    <author fullname="Mike Jones" initials="M." surname="Jones">
+      <organization>Microsoft</organization>
+    </author>
+    <author fullname="Breno de Medeiros" initials="B." surname="de Medeiros">
+      <organization>Google</organization>
+    </author>
+    <author fullname="Chuck Mortimore" initials="C." surname="Mortimore">
+      <organization>Salesforce</organization>
+    </author>
+    <date year="2014" month="Nov" day="8"></date>
+  </front>
+</reference>
+<reference anchor="OIDD" target="https://openid.net/specs/openid-connect-discovery-1_0.html">
+  <front>
+    <title>OpenID Connect Discovery 1.0 incorporating errata set 1</title>
+    <author fullname="Nat Sakimura" initials="N." surname="Sakimura">
+      <organization>NRI</organization>
+    </author>
+    <author fullname="John Bradley" initials="J." surname="Bradley">
+      <organization>Ping Identity</organization>
+    </author>
+    <author fullname="Mike Jones" initials="M." surname="Jones">
+      <organization>Microsoft</organization>
+    </author>
+    <author fullname="Edmund Jay" initials="E." surname="Jay">
+      <organization>Illumila</organization>
+    </author>
+    <date year="2014" month="Nov" day="8"></date>
+  </front>
+</reference>
+<reference anchor="OISM" target="http://openid.net/specs/openid-connect-session-1_0.html">
+  <front>
+    <title>OpenID Connect Session Management 1.0</title>
+    <author fullname="Breno de Medeiros" initials="B." surname="de Medeiros">
+      <organization>Google</organization>
+    </author>
+    <author fullname="Naveen Agarwal" initials="N." surname="Agarwal">
+      <organization>Microsoft</organization>
+    </author>
+    <author fullname="Nat Sakimura" initials="N." surname="Sakimura">
+      <organization abbrev="NAT.Consulting">NAT.Consulting</organization>
+    </author>
+    <author fullname="John Bradley" initials="J." surname="Bradley">
+      <organization abbrev="Yubico">Yubico</organization>
+    </author>
+    <author fullname="Michael B. Jones" initials="M.B." surname="Jones">
+      <organization abbrev="Microsoft">Microsoft</organization>
+    </author>
+    <date year="2022" month="March" day="14"></date>
+  </front>
+</reference>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7591.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7636.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8414.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9700.xml"/>
+</references>
+
+<section anchor="acknowledgements"><name>Acknowledgements</name>
+<t>The following people contributed to this document:</t>
+
+<ul spacing="compact">
+<li>Torsten Lodderstedt (SPRIND), Editor</li>
+<li>Brian Campbell (Ping Identity), Co-editor</li>
+<li>Nat Sakimura (NAT Consulting LLC) -- Chair</li>
+<li>Dave Tonge (Moneyhub) -- Chair</li>
+<li>Joseph Heenan (Authlete)</li>
+<li>Ralph Bragg (Raidiam)</li>
+<li>Vladimir Dzhuvinov (Connect2ID)</li>
+<li>Michael Schwartz (Gluu)</li>
+<li>Filip Skokan (Auth0|Okta)</li>
+</ul>
+</section>
+
+<section anchor="notices"><name>Notices</name>
+<t>Copyright (c) 2025 The OpenID Foundation.</t>
+<t>The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
+or other interested party a non-exclusive, royalty free, worldwide copyright license to
+reproduce, prepare derivative works from, distribute, perform and display, this
+Implementers Draft, Final Specification, or Final Specification Incorporating Errata
+Corrections solely for the purposes of (i) developing specifications, and (ii)
+implementing Implementers Drafts, Final Specifications, and Final Specification
+Incorporating Errata Corrections based on such documents, provided that attribution
+be made to the OIDF as the source of the material, but that such attribution does not
+indicate an endorsement by the OIDF.</t>
+<t>The technology described in this specification was made available from contributions
+from various sources, including members of the OpenID Foundation and others.
+Although the OpenID Foundation has taken steps to help ensure that the technology
+is available for distribution, it takes no position regarding the validity or scope of any
+intellectual property or other rights that might be claimed to pertain to the
+implementation or use of the technology described in this specification or the extent
+to which any license under such rights might or might not be available; neither does it
+represent that it has made any independent effort to identify any such rights. The
+OpenID Foundation and the contributors to this specification make no (and hereby
+expressly disclaim any) warranties (express, implied, or otherwise), including implied
+warranties of merchantability, non-infringement, fitness for a particular purpose, or
+title, related to this specification, and the entire risk as to implementing this
+specification is assumed by the implementer. The OpenID Intellectual Property
+Rights policy (found at openid.net) requires contributors to offer a patent promise not
+to assert certain patent claims against other contributors and against implementers.
+OpenID invites any interested party to bring to its attention any copyrights, patents,
+patent applications, or other proprietary rights that may cover technology that may be
+required to practice this specification.</t>
+</section>
+
+<section anchor="document-history"><name>Document History</name>
+<t>[[ To be removed from the approved specification incorporating errata corrections ]]</t>
+<t>-05</t>
+
+<ul spacing="compact">
+<li>Resolve JARM IANA registration review feedback</li>
+<li>Update copyright notice</li>
+<li>Update author and contributor associations</li>
+<li>Update security topics reference to RFC970</li>
+</ul>
+</section>
+
+</back>
+
+</rfc>


### PR DESCRIPTION
The tool currently doesn't handle errata drafts correctly so add specs manually. Checks have been run at https://github.com/openid/publication/pull/63 and only fail in expected ways.