### PR TITLE
Fix PR closing race condition

### DIFF
--- a/.github/workflows/oidf-publish.yml
+++ b/.github/workflows/oidf-publish.yml
@@ -81,12 +81,6 @@ jobs:
           # Push changes to remote
           git push origin ${{ github.event.pull_request.base.ref }}
 
-      - name: Github tidy up
-        run: |
-          gh pr close ${{ github.event.pull_request.number }} --delete-branch
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Update remote clone on OIDF Web Server
         uses: appleboy/ssh-action@v1.0.3
         with:


### PR DESCRIPTION
Publication of https://github.com/openid/publication/pull/90 aborted

This appears to be because github marked the merge request as merged, because the publication tool had merged the commits in the merge request. Then the cleanup step tried to close the already closed merge request, resulting in a failure that prevented the publication step running.

As github is closing the MR we don't need to do so manually, so remove that step. This will mean the branch isn't deleted I think, but that seems better than having an unreliable tool.