### PR TITLE
Add FAPI2 Message Signing Final

### DIFF
--- a/fapi/fapi-message-signing-2_0-final.html
+++ b/fapi/fapi-message-signing-2_0-final.html
@@ -1,0 +1,1999 @@
+<!DOCTYPE html>
+<html lang="en" class="Internet-Draft">
+<head>
+<meta charset="utf-8">
+<meta content="Common,Latin" name="scripts">
+<meta content="initial-scale=1.0" name="viewport">
+<title>FAPI 2.0 Message Signing</title>
+<meta content="Dave Tonge" name="author">
+<meta content="Daniel Fett" name="author">
+<meta content="Joseph Heenan" name="author">
+<meta content="
+       OIDF FAPI 2.0 Message Signing is an API security profile for signing and verifying certain FAPI 2.0 Security Profile   based requests and responses. 
+    " name="description">
+<meta content="xml2rfc 3.16.0" name="generator">
+<meta content="security" name="keyword">
+<meta content="openid" name="keyword">
+<meta content="fapi-message-signing-2_0-02" name="ietf.draft">
+<!-- Generator version information:
+  xml2rfc 3.16.0
+    Python 3.10.2
+    appdirs 1.4.4
+    ConfigArgParse 1.5.3
+    google-i18n-address 2.5.2
+    html5lib 1.1
+    intervaltree 3.1.0
+    Jinja2 3.1.2
+    lxml 4.9.2
+    MarkupSafe 2.1.2
+    pycountry 22.3.5
+    PyYAML 6.0
+    requests 2.28.2
+    setuptools 57.5.0
+    six 1.16.0
+    wcwidth 0.2.6
+-->
+<link href="./fapi-message-signing-2_0-02.xml" rel="alternate" type="application/rfc+xml">
+<link href="#copyright" rel="license">
+<style type="text/css">/*
+
+  NOTE: Changes at the bottom of this file overrides some earlier settings.
+
+  Once the style has stabilized and has been adopted as an official RFC style,
+  this can be consolidated so that style settings occur only in one place, but
+  for now the contents of this file consists first of the initial CSS work as
+  provided to the RFC Formatter (xml2rfc) work, followed by itemized and
+  commented changes found necessary during the development of the v3
+  formatters.
+
+*/
+
+/* fonts */
+@import url('https://fonts.googleapis.com/css?family=Noto+Sans'); /* Sans-serif */
+@import url('https://fonts.googleapis.com/css?family=Noto+Serif'); /* Serif (print) */
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono'); /* Monospace */
+
+:root {
+  --font-sans: 'Noto Sans', Arial, Helvetica, sans-serif;
+  --font-serif: 'Noto Serif', 'Times', 'Times New Roman', serif;
+  --font-mono: 'Roboto Mono', Courier, 'Courier New', monospace;
+}
+
+@viewport {
+  zoom: 1.0;
+  width: extend-to-zoom;
+}
+@-ms-viewport {
+  width: extend-to-zoom;
+  zoom: 1.0;
+}
+/* general and mobile first */
+html {
+}
+body {
+  max-width: 90%;
+  margin: 1.5em auto;
+  color: #222;
+  background-color: #fff;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  scroll-behavior: smooth;
+}
+.ears {
+  display: none;
+}
+
+/* headings */
+#title, h1, h2, h3, h4, h5, h6 {
+  margin: 1em 0 0.5em;
+  font-weight: bold;
+  line-height: 1.3;
+}
+#title {
+  clear: both;
+  border-bottom: 1px solid #ddd;
+  margin: 0 0 0.5em 0;
+  padding: 1em 0 0.5em;
+}
+.author {
+  padding-bottom: 4px;
+}
+h1 {
+  font-size: 26px;
+  margin: 1em 0;
+}
+h2 {
+  font-size: 22px;
+  margin-top: -20px;  /* provide offset for in-page anchors */
+  padding-top: 33px;
+}
+h3 {
+  font-size: 18px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h4 {
+  font-size: 16px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h5, h6 {
+  font-size: 14px;
+}
+#n-copyright-notice {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+}
+/* general structure */
+p {
+  padding: 0;
+  margin: 0 0 1em 0;
+  text-align: left;
+}
+div, span {
+  position: relative;
+}
+div {
+  margin: 0;
+}
+.alignRight.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignRight.art-text pre {
+  padding: 0;
+}
+.alignRight {
+  margin: 1em 0;
+}
+.alignRight > *:first-child {
+  border: none;
+  margin: 0;
+  float: right;
+  clear: both;
+}
+.alignRight > *:nth-child(2) {
+  clear: both;
+  display: block;
+  border: none;
+}
+svg {
+  display: block;
+}
+svg[font-family~="serif" i], svg [font-family~="serif" i] {
+  font-family: var(--font-serif);
+}
+svg[font-family~="sans-serif" i], svg [font-family~="sans-serif" i] {
+  font-family: var(--font-sans);
+}
+svg[font-family~="monospace" i], svg [font-family~="monospace" i] {
+  font-family: var(--font-mono);
+}
+.alignCenter.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignCenter.art-text pre {
+  padding: 0;
+}
+.alignCenter {
+  margin: 1em 0;
+}
+.alignCenter > *:first-child {
+  display: table;
+  border: none;
+  margin: 0 auto;
+}
+
+/* lists */
+ol, ul {
+  padding: 0;
+  margin: 0 0 1em 2em;
+}
+ol ol, ul ul, ol ul, ul ol {
+  margin-left: 1em;
+}
+li {
+  margin: 0 0 0.25em 0;
+}
+.ulCompact li {
+  margin: 0;
+}
+ul.empty, .ulEmpty {
+  list-style-type: none;
+}
+ul.empty li, .ulEmpty li {
+  margin-top: 0.5em;
+}
+ul.ulBare, li.ulBare {
+  margin-left: 0em !important;
+}
+ul.compact, .ulCompact,
+ol.compact, .olCompact {
+  line-height: 100%;
+  margin: 0 0 0 2em;
+}
+
+/* definition lists */
+dl {
+}
+dl > dt {
+  float: left;
+  margin-right: 1em;
+}
+/* 
+dl.nohang > dt {
+  float: none;
+}
+*/
+dl > dd {
+  margin-bottom: .8em;
+  min-height: 1.3em;
+}
+dl.compact > dd, .dlCompact > dd {
+  margin-bottom: 0em;
+}
+dl > dd > dl {
+  margin-top: 0.5em;
+  margin-bottom: 0em;
+}
+
+/* links */
+a {
+  text-decoration: none;
+}
+a[href] {
+  color: #22e; /* Arlen: WCAG 2019 */
+}
+a[href]:hover {
+  background-color: #f2f2f2;
+}
+figcaption a[href],
+a[href].selfRef {
+  color: #222;
+}
+/* XXX probably not this:
+a.selfRef:hover {
+  background-color: transparent;
+  cursor: default;
+} */
+
+/* Figures */
+tt, code, pre {
+  background-color: #f9f9f9;
+  font-family: var(--font-mono);
+}
+pre {
+  border: 1px solid #eee;
+  margin: 0;
+  padding: 1em;
+}
+img {
+  max-width: 100%;
+}
+figure {
+  margin: 0;
+}
+figure blockquote {
+  margin: 0.8em 0.4em 0.4em;
+}
+figcaption {
+  font-style: italic;
+  margin: 0 0 1em 0;
+}
+@media screen {
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
+    max-width: calc(100% - 22px);
+  }
+}
+
+/* aside, blockquote */
+aside, blockquote {
+  margin-left: 0;
+  padding: 1.2em 2em;
+}
+blockquote {
+  background-color: #f9f9f9;
+  color: #111; /* Arlen: WCAG 2019 */
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  margin: 1em 0;
+}
+cite {
+  display: block;
+  text-align: right;
+  font-style: italic;
+}
+
+/* tables */
+table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+}
+th, td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.5em 0.75em;
+}
+th {
+  text-align: left;
+  background-color: #e9e9e9;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f5f5f5;
+}
+table caption {
+  font-style: italic;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+table p {
+  /* XXX to avoid bottom margin on table row signifiers. If paragraphs should
+     be allowed within tables more generally, it would be far better to select on a class. */
+  margin: 0;
+}
+
+/* pilcrow */
+a.pilcrow {
+  color: #666; /* Arlen: AHDJ 2019 */
+  text-decoration: none;
+  visibility: hidden;
+  user-select: none;
+  -ms-user-select: none;
+  -o-user-select:none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+@media screen {
+  aside:hover > a.pilcrow,
+  p:hover > a.pilcrow,
+  blockquote:hover > a.pilcrow,
+  div:hover > a.pilcrow,
+  li:hover > a.pilcrow,
+  pre:hover > a.pilcrow {
+    visibility: visible;
+  }
+  a.pilcrow:hover {
+    background-color: transparent;
+  }
+}
+
+/* misc */
+hr {
+  border: 0;
+  border-top: 1px solid #eee;
+}
+.bcp14 {
+  font-variant: small-caps;
+}
+
+.role {
+  font-variant: all-small-caps;
+}
+
+/* info block */
+#identifiers {
+  margin: 0;
+  font-size: 0.9em;
+}
+#identifiers dt {
+  width: 3em;
+  clear: left;
+}
+#identifiers dd {
+  float: left;
+  margin-bottom: 0;
+}
+/* Fix PDF info block run off issue */
+@media print {
+  #identifiers dd {
+    float: none;
+  }
+}
+#identifiers .authors .author {
+  display: inline-block;
+  margin-right: 1.5em;
+}
+#identifiers .authors .org {
+  font-style: italic;
+}
+
+/* The prepared/rendered info at the very bottom of the page */
+.docInfo {
+  color: #666; /* Arlen: WCAG 2019 */
+  font-size: 0.9em;
+  font-style: italic;
+  margin-top: 2em;
+}
+.docInfo .prepared {
+  float: left;
+}
+.docInfo .prepared {
+  float: right;
+}
+
+/* table of contents */
+#toc  {
+  padding: 0.75em 0 2em 0;
+  margin-bottom: 1em;
+}
+nav.toc ul {
+  margin: 0 0.5em 0 0;
+  padding: 0;
+  list-style: none;
+}
+nav.toc li {
+  line-height: 1.3em;
+  margin: 0.75em 0;
+  padding-left: 1.2em;
+  text-indent: -1.2em;
+}
+/* references */
+.references dt {
+  text-align: right;
+  font-weight: bold;
+  min-width: 7em;
+}
+.references dd {
+  margin-left: 8em;
+  overflow: auto;
+}
+
+.refInstance {
+  margin-bottom: 1.25em;
+}
+
+.references .ascii {
+  margin-bottom: 0.25em;
+}
+
+/* index */
+.index ul {
+  margin: 0 0 0 1em;
+  padding: 0;
+  list-style: none;
+}
+.index ul ul {
+  margin: 0;
+}
+.index li {
+  margin: 0;
+  text-indent: -2em;
+  padding-left: 2em;
+  padding-bottom: 5px;
+}
+.indexIndex {
+  margin: 0.5em 0 1em;
+}
+.index a {
+  font-weight: 700;
+}
+/* make the index two-column on all but the smallest screens */
+@media (min-width: 600px) {
+  .index ul {
+    -moz-column-count: 2;
+    -moz-column-gap: 20px;
+  }
+  .index ul ul {
+    -moz-column-count: 1;
+    -moz-column-gap: 0;
+  }
+}
+
+/* authors */
+address.vcard {
+  font-style: normal;
+  margin: 1em 0;
+}
+
+address.vcard .nameRole {
+  font-weight: 700;
+  margin-left: 0;
+}
+address.vcard .label {
+  font-family: var(--font-sans);
+  margin: 0.5em 0;
+}
+address.vcard .type {
+  display: none;
+}
+.alternative-contact {
+  margin: 1.5em 0 1em;
+}
+hr.addr {
+  border-top: 1px dashed;
+  margin: 0;
+  color: #ddd;
+  max-width: calc(100% - 16px);
+}
+
+/* temporary notes */
+.rfcEditorRemove::before {
+  position: absolute;
+  top: 0.2em;
+  right: 0.2em;
+  padding: 0.2em;
+  content: "The RFC Editor will remove this note";
+  color: #9e2a00; /* Arlen: WCAG 2019 */
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+}
+.rfcEditorRemove {
+  position: relative;
+  padding-top: 1.8em;
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  border-radius: 3px;
+}
+.cref {
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  padding: 2px 4px;
+}
+.crefSource {
+  font-style: italic;
+}
+/* alternative layout for smaller screens */
+@media screen and (max-width: 1023px) {
+  body {
+    padding-top: 2em;
+  }
+  #title {
+    padding: 1em 0;
+  }
+  h1 {
+    font-size: 24px;
+  }
+  h2 {
+    font-size: 20px;
+    margin-top: -18px;  /* provide offset for in-page anchors */
+    padding-top: 38px;
+  }
+  #identifiers dd {
+    max-width: 60%;
+  }
+  #toc {
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    padding: 0;
+    margin: 0;
+    background-color: inherit;
+    border-bottom: 1px solid #ccc;
+  }
+  #toc h2 {
+    margin: -1px 0 0 0;
+    padding: 4px 0 4px 6px;
+    padding-right: 1em;
+    min-width: 190px;
+    font-size: 1.1em;
+    text-align: right;
+    background-color: #444;
+    color: white;
+    cursor: pointer;
+  }
+  #toc h2::before { /* css hamburger */
+    float: right;
+    position: relative;
+    width: 1em;
+    height: 1px;
+    left: -164px;
+    margin: 6px 0 0 0;
+    background: white none repeat scroll 0 0;
+    box-shadow: 0 4px 0 0 white, 0 8px 0 0 white;
+    content: "";
+  }
+  #toc nav {
+    display: none;
+    padding: 0.5em 1em 1em;
+    overflow: auto;
+    height: calc(100vh - 48px);
+    border-left: 1px solid #ddd;
+  }
+}
+
+/* alternative layout for wide screens */
+@media screen and (min-width: 1024px) {
+  body {
+    max-width: 724px;
+    margin: 42px auto;
+    padding-left: 1.5em;
+    padding-right: 29em;
+  }
+  #toc {
+    position: fixed;
+    top: 42px;
+    right: 42px;
+    width: 25%;
+    margin: 0;
+    padding: 0 1em;
+    z-index: 1;
+  }
+  #toc h2 {
+    border-top: none;
+    border-bottom: 1px solid #ddd;
+    font-size: 1em;
+    font-weight: normal;
+    margin: 0;
+    padding: 0.25em 1em 1em 0;
+  }
+  #toc nav {
+    display: block;
+    height: calc(90vh - 84px);
+    bottom: 0;
+    padding: 0.5em 0 0;
+    overflow: auto;
+  }
+  img { /* future proofing */
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+/* pagination */
+@media print {
+  body {
+
+    width: 100%;
+  }
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+  #n-copyright-notice {
+    border-bottom: none;
+  }
+  #toc, #n-introduction {
+    page-break-before: always;
+  }
+  #toc {
+    border-top: none;
+    padding-top: 0;
+  }
+  figure, pre {
+    page-break-inside: avoid;
+  }
+  figure {
+    overflow: scroll;
+  }
+  .breakable pre {
+    break-inside: auto;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+  h2+*, h3+*, h4+*, h5+*, h6+* {
+    page-break-before: avoid;
+  }
+  pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-size: 10pt;
+  }
+  table {
+    border: 1px solid #ddd;
+  }
+  td {
+    border-top: 1px solid #ddd;
+  }
+}
+
+/* This is commented out here, as the string-set: doesn't
+   pass W3C validation currently */
+/*
+.ears thead .left {
+  string-set: ears-top-left content();
+}
+
+.ears thead .center {
+  string-set: ears-top-center content();
+}
+
+.ears thead .right {
+  string-set: ears-top-right content();
+}
+
+.ears tfoot .left {
+  string-set: ears-bottom-left content();
+}
+
+.ears tfoot .center {
+  string-set: ears-bottom-center content();
+}
+
+.ears tfoot .right {
+  string-set: ears-bottom-right content();
+}
+*/
+
+@page :first {
+  padding-top: 0;
+  @top-left {
+    content: normal;
+    border: none;
+  }
+  @top-center {
+    content: normal;
+    border: none;
+  }
+  @top-right {
+    content: normal;
+    border: none;
+  }
+}
+
+@page {
+  size: A4;
+  margin-bottom: 45mm;
+  padding-top: 20px;
+  /* The following is commented out here, but set appropriately by in code, as
+     the content depends on the document */
+  /*
+  @top-left {
+    content: 'Internet-Draft';
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-left {
+    content: string(ears-top-left);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-center {
+    content: string(ears-top-center);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-right {
+    content: string(ears-top-right);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @bottom-left {
+    content: string(ears-bottom-left);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-center {
+    content: string(ears-bottom-center);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-right {
+      content: '[Page ' counter(page) ']';
+      vertical-align: top;
+      border-top: solid 1px #ccc;
+  }
+  */
+
+}
+
+/* Changes introduced to fix issues found during implementation */
+/* Make sure links are clickable even if overlapped by following H* */
+a {
+  z-index: 2;
+}
+/* Separate body from document info even without intervening H1 */
+section {
+  clear: both;
+}
+
+
+/* Top align author divs, to avoid names without organization dropping level with org names */
+.author {
+  vertical-align: top;
+}
+
+/* Leave room in document info to show Internet-Draft on one line */
+#identifiers dt {
+  width: 8em;
+}
+
+/* Don't waste quite as much whitespace between label and value in doc info */
+#identifiers dd {
+  margin-left: 1em;
+}
+
+/* Give floating toc a background color (needed when it's a div inside section */
+#toc {
+  background-color: white;
+}
+
+/* Make the collapsed ToC header render white on gray also when it's a link */
+@media screen and (max-width: 1023px) {
+  #toc h2 a,
+  #toc h2 a:link,
+  #toc h2 a:focus,
+  #toc h2 a:hover,
+  #toc a.toplink,
+  #toc a.toplink:hover {
+    color: white;
+    background-color: #444;
+    text-decoration: none;
+  }
+}
+
+/* Give the bottom of the ToC some whitespace */
+@media screen and (min-width: 1024px) {
+  #toc {
+    padding: 0 0 1em 1em;
+  }
+}
+
+/* Style section numbers with more space between number and title */
+.section-number {
+  padding-right: 0.5em;
+}
+
+/* prevent monospace from becoming overly large */
+tt, code, pre {
+  font-size: 95%;
+}
+
+/* Fix the height/width aspect for ascii art*/
+.sourcecode pre,
+.art-text pre {
+  line-height: 1.12;
+}
+
+
+/* Add styling for a link in the ToC that points to the top of the document */
+a.toplink {
+  float: right;
+  margin-right: 0.5em;
+}
+
+/* Fix the dl styling to match the RFC 7992 attributes */
+dl > dt,
+dl.dlParallel > dt {
+  float: left;
+  margin-right: 1em;
+}
+dl.dlNewline > dt {
+  float: none;
+}
+
+/* Provide styling for table cell text alignment */
+table td.text-left,
+table th.text-left {
+  text-align: left;
+}
+table td.text-center,
+table th.text-center {
+  text-align: center;
+}
+table td.text-right,
+table th.text-right {
+  text-align: right;
+}
+
+/* Make the alternative author contact information look less like just another
+   author, and group it closer with the primary author contact information */
+.alternative-contact {
+  margin: 0.5em 0 0.25em 0;
+}
+address .non-ascii {
+  margin: 0 0 0 2em;
+}
+
+/* With it being possible to set tables with alignment
+  left, center, and right, { width: 100%; } does not make sense */
+table {
+  width: auto;
+}
+
+/* Avoid reference text that sits in a block with very wide left margin,
+   because of a long floating dt label.*/
+.references dd {
+  overflow: visible;
+}
+
+/* Control caption placement */
+caption {
+  caption-side: bottom;
+}
+
+/* Limit the width of the author address vcard, so names in right-to-left
+   script don't end up on the other side of the page. */
+
+address.vcard {
+  max-width: 30em;
+  margin-right: auto;
+}
+
+/* For address alignment dependent on LTR or RTL scripts */
+address div.left {
+  text-align: left;
+}
+address div.right {
+  text-align: right;
+}
+
+/* Provide table alignment support.  We can't use the alignX classes above
+   since they do unwanted things with caption and other styling. */
+table.right {
+ margin-left: auto;
+ margin-right: 0;
+}
+table.center {
+ margin-left: auto;
+ margin-right: auto;
+}
+table.left {
+ margin-left: 0;
+ margin-right: auto;
+}
+
+/* Give the table caption label the same styling as the figcaption */
+caption a[href] {
+  color: #222;
+}
+
+@media print {
+  .toplink {
+    display: none;
+  }
+
+  /* avoid overwriting the top border line with the ToC header */
+  #toc {
+    padding-top: 1px;
+  }
+
+  /* Avoid page breaks inside dl and author address entries */
+  .vcard {
+    page-break-inside: avoid;
+  }
+
+}
+/* Tweak the bcp14 keyword presentation */
+.bcp14 {
+  font-variant: small-caps;
+  font-weight: bold;
+  font-size: 0.9em;
+}
+/* Tweak the invisible space above H* in order not to overlay links in text above */
+ h2 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 31px;
+ }
+ h3 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+ h4 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+/* Float artwork pilcrow to the right */
+@media screen {
+  .artwork a.pilcrow {
+    display: block;
+    line-height: 0.7;
+    margin-top: 0.15em;
+  }
+}
+/* Make pilcrows on dd visible */
+@media screen {
+  dd:hover > a.pilcrow {
+    visibility: visible;
+  }
+}
+/* Make the placement of figcaption match that of a table's caption
+   by removing the figure's added bottom margin */
+.alignLeft.art-text,
+.alignCenter.art-text,
+.alignRight.art-text {
+   margin-bottom: 0;
+}
+.alignLeft,
+.alignCenter,
+.alignRight {
+  margin: 1em 0 0 0;
+}
+/* In print, the pilcrow won't show on hover, so prevent it from taking up space,
+   possibly even requiring a new line */
+@media print {
+  a.pilcrow {
+    display: none;
+  }
+}
+/* Styling for the external metadata */
+div#external-metadata {
+  background-color: #eee;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  display: none;
+}
+div#internal-metadata {
+  padding: 0.5em;                       /* to match the external-metadata padding */
+}
+/* Styling for title RFC Number */
+h1#rfcnum {
+  clear: both;
+  margin: 0 0 -1em;
+  padding: 1em 0 0 0;
+}
+/* Make .olPercent look the same as <ol><li> */
+dl.olPercent > dd {
+  margin-bottom: 0.25em;
+  min-height: initial;
+}
+/* Give aside some styling to set it apart */
+aside {
+  border-left: 1px solid #ddd;
+  margin: 1em 0 1em 2em;
+  padding: 0.2em 2em;
+}
+aside > dl,
+aside > ol,
+aside > ul,
+aside > table,
+aside > p {
+  margin-bottom: 0.5em;
+}
+/* Additional page break settings */
+@media print {
+  figcaption, table caption {
+    page-break-before: avoid;
+  }
+}
+/* Font size adjustments for print */
+@media print {
+  body  { font-size: 10pt;      line-height: normal; max-width: 96%; }
+  h1    { font-size: 1.72em;    padding-top: 1.5em; } /* 1*1.2*1.2*1.2 */
+  h2    { font-size: 1.44em;    padding-top: 1.5em; } /* 1*1.2*1.2 */
+  h3    { font-size: 1.2em;     padding-top: 1.5em; } /* 1*1.2 */
+  h4    { font-size: 1em;       padding-top: 1.5em; }
+  h5, h6 { font-size: 1em;      margin: initial; padding: 0.5em 0 0.3em; }
+}
+/* Sourcecode margin in print, when there's no pilcrow */
+@media print {
+  .artwork,
+  .artwork > pre,
+  .sourcecode {
+    margin-bottom: 1em;
+  }
+}
+/* Avoid narrow tables forcing too narrow table captions, which may render badly */
+table {
+  min-width: 20em;
+}
+/* ol type a */
+ol.type-a { list-style-type: lower-alpha; }
+ol.type-A { list-style-type: upper-alpha; }
+ol.type-i { list-style-type: lower-roman; }
+ol.type-I { list-style-type: lower-roman; }
+/* Apply the print table and row borders in general, on request from the RPC,
+and increase the contrast between border and odd row background slightly */
+table {
+  border: 1px solid #ddd;
+}
+td {
+  border-top: 1px solid #ddd;
+}
+tr {
+  break-inside: avoid;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f8f8f8;
+}
+/* Use style rules to govern display of the TOC. */
+@media screen and (max-width: 1023px) {
+  #toc nav { display: none; }
+  #toc.active nav { display: block; }
+}
+/* Add support for keepWithNext */
+.keepWithNext {
+  break-after: avoid-page;
+  break-after: avoid-page;
+}
+/* Add support for keepWithPrevious */
+.keepWithPrevious {
+  break-before: avoid-page;
+}
+/* Change the approach to avoiding breaks inside artwork etc. */
+figure, pre, table, .artwork, .sourcecode  {
+  break-before: auto;
+  break-after: auto;
+}
+/* Avoid breaks between <dt> and <dd> */
+dl {
+  break-before: auto;
+  break-inside: auto;
+}
+dt {
+  break-before: auto;
+  break-after: avoid-page;
+}
+dd {
+  break-before: avoid-page;
+  break-after: auto;
+  orphans: 3;
+  widows: 3
+}
+span.break, dd.break {
+  margin-bottom: 0;
+  min-height: 0;
+  break-before: auto;
+  break-inside: auto;
+  break-after: auto;
+}
+/* Undo break-before ToC */
+@media print {
+  #toc {
+    break-before: auto;
+  }
+}
+/* Text in compact lists should not get extra bottom margin space,
+   since that would makes the list not compact */
+ul.compact p, .ulCompact p,
+ol.compact p, .olCompact p {
+ margin: 0;
+}
+/* But the list as a whole needs the extra space at the end */
+section ul.compact,
+section .ulCompact,
+section ol.compact,
+section .olCompact {
+  margin-bottom: 1em;                    /* same as p not within ul.compact etc. */
+}
+/* The tt and code background above interferes with for instance table cell
+   backgrounds.  Changed to something a bit more selective. */
+tt, code {
+  background-color: transparent;
+}
+p tt, p code, li tt, li code {
+  background-color: #f8f8f8;
+}
+/* Tweak the pre margin -- 0px doesn't come out well */
+pre {
+   margin-top: 0.5px;
+}
+/* Tweak the compact list text */
+ul.compact, .ulCompact,
+ol.compact, .olCompact,
+dl.compact, .dlCompact {
+  line-height: normal;
+}
+/* Don't add top margin for nested lists */
+li > ul, li > ol, li > dl,
+dd > ul, dd > ol, dd > dl,
+dl > dd > dl {
+  margin-top: initial;
+}
+/* Elements that should not be rendered on the same line as a <dt> */
+/* This should match the element list in writer.text.TextWriter.render_dl() */
+dd > div.artwork:first-child,
+dd > aside:first-child,
+dd > figure:first-child,
+dd > ol:first-child,
+dd > div.sourcecode:first-child,
+dd > table:first-child,
+dd > ul:first-child {
+  clear: left;
+}
+/* fix for weird browser behaviour when <dd/> is empty */
+dt+dd:empty::before{
+  content: "\00a0";
+}
+/* Make paragraph spacing inside <li> smaller than in body text, to fit better within the list */
+li > p {
+  margin-bottom: 0.5em
+}
+/* Don't let p margin spill out from inside list items */
+li > p:last-of-type:only-child {
+  margin-bottom: 0;
+}
+</style>
+<link href="rfc-local.css" rel="stylesheet" type="text/css">
+</head>
+<body class="xml2rfc">
+<script src="metadata.min.js"></script>
+<table class="ears">
+<thead><tr>
+<td class="left"></td>
+<td class="center">fapi-message-signing-2</td>
+<td class="right">September 2025</td>
+</tr></thead>
+<tfoot><tr>
+<td class="left">Tonge, et al.</td>
+<td class="center">Standards Track</td>
+<td class="right">[Page]</td>
+</tr></tfoot>
+</table>
+<div id="external-metadata" class="document-information"></div>
+<div id="internal-metadata" class="document-information">
+<dl id="identifiers">
+<dt class="label-workgroup">Workgroup:</dt>
+<dd class="workgroup">fapi</dd>
+<dt class="label-published">Published:</dt>
+<dd class="published">
+<time datetime="2025-09-25" class="published">25 September 2025</time>
+    </dd>
+<dt class="label-status">Status:</dt>
+<dd class="status">Final</dd>
+<dt class="label-authors">Authors:</dt>
+<dd class="authors">
+<div class="author">
+      <div class="author-name">D. Tonge</div>
+<div class="org">Moneyhub Financial Technology</div>
+</div>
+<div class="author">
+      <div class="author-name">D. Fett</div>
+<div class="org">Authlete</div>
+</div>
+<div class="author">
+      <div class="author-name">J. Heenan</div>
+<div class="org">Authlete</div>
+</div>
+</dd>
+</dl>
+</div>
+<h1 id="title">FAPI 2.0 Message Signing</h1>
+<section id="section-abstract">
+      <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
+<p id="section-abstract-1">OIDF FAPI 2.0 Message Signing is an API security profile for signing and verifying certain FAPI 2.0 Security Profile <span>[<a href="#FAPI2_Security_Profile" class="cite xref">FAPI2_Security_Profile</a>]</span> based requests and responses.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+</section>
+<section class="note" id="section-note.1">
+      <h2 id="name-foreword">
+<a href="#name-foreword" class="section-name selfRef">Foreword</a>
+      </h2>
+<p id="section-note.1-1">The OpenID Foundation (OIDF) promotes, protects and nurtures the OpenID community and technologies. As a non-profit international standardizing body, it is comprised by over 160 participating entities (workgroup participant). The work of preparing implementer drafts and final international standards is carried out through OIDF workgroups in accordance with the OpenID Process. Participants interested in a subject for which a workgroup has been established have the right to be represented in that workgroup. International organizations, governmental and non-governmental, in liaison with OIDF, also take part in the work. OIDF collaborates closely with other standardizing bodies in the related fields.<a href="#section-note.1-1" class="pilcrow">¶</a></p>
+<p id="section-note.1-2">Final drafts adopted by the Workgroup through consensus are circulated publicly for the public review for 60 days and for the OIDF members for voting. Publication as an OIDF Standard requires approval by at least 50% of the members casting a vote. There is a possibility that some of the elements of this document may be the subject to patent rights. OIDF shall not be held responsible for identifying any or all such patent rights.<a href="#section-note.1-2" class="pilcrow">¶</a></p>
+</section>
+<section class="note" id="section-note.2">
+      <h2 id="name-introduction">
+<a href="#name-introduction" class="section-name selfRef">Introduction</a>
+      </h2>
+<p id="section-note.2-1">OIDF FAPI 2.0 is an API security profile based on the OAuth 2.0 Authorization
+Framework <span>[<a href="#RFC6749" class="cite xref">RFC6749</a>]</span>. This Message Signing Profile is part of the FAPI 2.0 family of specifications with a focus on providing interoperable support for non-repudiation across OAuth 2.0 based requests and responses.<a href="#section-note.2-1" class="pilcrow">¶</a></p>
+<p id="section-note.2-2">It has been formally analysed <span>[<a href="#FAPI2MSANALYSIS" class="cite xref">FAPI2MSANALYSIS</a>]</span> for it's security and non-repudiation properties.<a href="#section-note.2-2" class="pilcrow">¶</a></p>
+</section>
+<section class="note" id="section-note.3">
+      <h2 id="name-warning">
+<a href="#name-warning" class="section-name selfRef">Warning</a>
+      </h2>
+<p id="section-note.3-1">This document is not an OIDF International Standard. It is distributed for
+review and comment. It is subject to change without notice and may not be
+referred to as an International Standard.<a href="#section-note.3-1" class="pilcrow">¶</a></p>
+<p id="section-note.3-2">Recipients of this draft are invited to submit, with their comments,
+notification of any relevant patent rights of which they are aware and to
+provide supporting documentation.<a href="#section-note.3-2" class="pilcrow">¶</a></p>
+</section>
+<section class="note" id="section-note.4">
+      <h2 id="name-notational-conventions">
+<a href="#name-notational-conventions" class="section-name selfRef">Notational conventions</a>
+      </h2>
+<p id="section-note.4-1">The keywords "shall", "shall not", "should", "should not", "may", and "can" in
+this document are to be interpreted as described in ISO Directive Part 2
+<span>[<a href="#ISODIR2" class="cite xref">ISODIR2</a>]</span>. These keywords are not used as dictionary terms such that any
+occurrence of them shall be interpreted as keywords and are not to be
+interpreted with their natural language meanings.<a href="#section-note.4-1" class="pilcrow">¶</a></p>
+</section>
+<div id="toc">
+<section id="section-toc.1">
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
+        </h2>
+<nav class="toc"><ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1">
+            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-scope" class="internal xref">Scope</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
+            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-normative-references" class="internal xref">Normative references</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
+            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-terms-and-definitions" class="internal xref">Terms and definitions</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-symbols-and-abbreviated-ter" class="internal xref">Symbols and Abbreviated terms</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-message-signing-profile" class="internal xref">Message signing profile</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.1">
+                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="auto internal xref">5.1</a>.  <a href="#name-profile" class="internal xref">Profile</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.2">
+                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="auto internal xref">5.2</a>.  <a href="#name-non-repudiation" class="internal xref">Non-repudiation</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3">
+                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="auto internal xref">5.3</a>.  <a href="#name-signing-authorization-reque" class="internal xref">Signing authorization requests</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3.2.1">
+                    <p id="section-toc.1-1.5.2.3.2.1.1"><a href="#section-5.3.1" class="auto internal xref">5.3.1</a>.  <a href="#name-requirements-for-authorizat" class="internal xref">Requirements for authorization servers</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3.2.2">
+                    <p id="section-toc.1-1.5.2.3.2.2.1"><a href="#section-5.3.2" class="auto internal xref">5.3.2</a>.  <a href="#name-requirements-for-clients" class="internal xref">Requirements for clients</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3.2.3">
+                    <p id="section-toc.1-1.5.2.3.2.3.1"><a href="#section-5.3.3" class="auto internal xref">5.3.3</a>.  <a href="#name-client-metadata" class="internal xref">Client metadata</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.4">
+                <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="auto internal xref">5.4</a>.  <a href="#name-signing-authorization-respo" class="internal xref">Signing authorization responses</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.4.2.1">
+                    <p id="section-toc.1-1.5.2.4.2.1.1"><a href="#section-5.4.1" class="auto internal xref">5.4.1</a>.  <a href="#name-requirements-for-authorizati" class="internal xref">Requirements for authorization servers</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.4.2.2">
+                    <p id="section-toc.1-1.5.2.4.2.2.1"><a href="#section-5.4.2" class="auto internal xref">5.4.2</a>.  <a href="#name-requirements-for-clients-2" class="internal xref">Requirements for clients</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.5">
+                <p id="section-toc.1-1.5.2.5.1"><a href="#section-5.5" class="auto internal xref">5.5</a>.  <a href="#name-signing-introspection-respo" class="internal xref">Signing introspection responses</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.5.2.1">
+                    <p id="section-toc.1-1.5.2.5.2.1.1"><a href="#section-5.5.1" class="auto internal xref">5.5.1</a>.  <a href="#name-requirements-for-authorizatio" class="internal xref">Requirements for authorization servers</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.5.2.2">
+                    <p id="section-toc.1-1.5.2.5.2.2.1"><a href="#section-5.5.2" class="auto internal xref">5.5.2</a>.  <a href="#name-requirements-for-clients-3" class="internal xref">Requirements for clients</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.6">
+                <p id="section-toc.1-1.5.2.6.1"><a href="#section-5.6" class="auto internal xref">5.6</a>.  <a href="#name-signing-id-tokens" class="internal xref">Signing ID tokens</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.6.2.1">
+                    <p id="section-toc.1-1.5.2.6.2.1.1"><a href="#section-5.6.1" class="auto internal xref">5.6.1</a>.  <a href="#name-requirements-for-authorization" class="internal xref">Requirements for authorization servers</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.6.2.2">
+                    <p id="section-toc.1-1.5.2.6.2.2.1"><a href="#section-5.6.2" class="auto internal xref">5.6.2</a>.  <a href="#name-requirements-for-clients-4" class="internal xref">Requirements for clients</a></p>
+</li>
+                </ul>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-security-considerations" class="internal xref">Security considerations</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1">
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="auto internal xref">6.1</a>.  <a href="#name-authorization-response-encr" class="internal xref">Authorization response encryption</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2">
+                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="auto internal xref">6.2</a>.  <a href="#name-confusion-between-resource-" class="internal xref">Confusion between resource servers and clients in introspection request</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.3">
+                <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="auto internal xref">6.3</a>.  <a href="#name-non-repudiation-limited-to-" class="internal xref">Non-repudiation limited to individual messages</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.4">
+                <p id="section-toc.1-1.6.2.4.1"><a href="#section-6.4" class="auto internal xref">6.4</a>.  <a href="#name-non-repudiation-not-provide" class="internal xref">Non-repudiation not provided for front channel authorization requests</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.5">
+                <p id="section-toc.1-1.6.2.5.1"><a href="#section-6.5" class="auto internal xref">6.5</a>.  <a href="#name-difficulty-in-linking-a-sig" class="internal xref">Difficulty in linking a signed message to a real world identity</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.6">
+                <p id="section-toc.1-1.6.2.6.1"><a href="#section-6.6" class="auto internal xref">6.6</a>.  <a href="#name-the-value-of-jarm-for-non-r" class="internal xref">The value of JARM for non-repudiation</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-privacy-considerations" class="internal xref">Privacy considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-iana-considerations" class="internal xref">IANA considerations</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.1">
+                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="auto internal xref">8.1</a>.  <a href="#name-oauth-dynamic-client-regist" class="internal xref">OAuth dynamic client registration metadata registration</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.1.2.1">
+                    <p id="section-toc.1-1.8.2.1.2.1.1"><a href="#section-8.1.1" class="auto internal xref">8.1.1</a>.  <a href="#name-registry-contents" class="internal xref">Registry contents</a></p>
+</li>
+                </ul>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-acknowledgements" class="internal xref">Acknowledgements</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="auto internal xref">10</a>. <a href="#name-normative-references-2" class="internal xref">Normative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="auto internal xref">11</a>. <a href="#name-informative-references" class="internal xref">Informative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
+            <p id="section-toc.1-1.12.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-notices" class="internal xref">Notices</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
+            <p id="section-toc.1-1.13.1"><a href="#appendix-B" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
+</li>
+        </ul>
+</nav>
+</section>
+</div>
+<div id="scope">
+<section id="section-1">
+      <h2 id="name-scope">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-scope" class="section-name selfRef">Scope</a>
+      </h2>
+<p id="section-1-1">This document specifies the methods for clients, authorization servers and resource servers to sign and verify messages.<a href="#section-1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="normative-references">
+<section id="section-2">
+      <h2 id="name-normative-references">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-normative-references" class="section-name selfRef">Normative references</a>
+      </h2>
+<p id="section-2-1">The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.<a href="#section-2-1" class="pilcrow">¶</a></p>
+<p id="section-2-2">See Clause 8 for normative references.<a href="#section-2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="terms-and-definitions">
+<section id="section-3">
+      <h2 id="name-terms-and-definitions">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-terms-and-definitions" class="section-name selfRef">Terms and definitions</a>
+      </h2>
+<p id="section-3-1">For the purpose of this document, the terms defined in <span>[<a href="#RFC6749" class="cite xref">RFC6749</a>]</span>, <span>[<a href="#RFC6750" class="cite xref">RFC6750</a>]</span>, <span>[<a href="#RFC7636" class="cite xref">RFC7636</a>]</span>, <span>[<a href="#OIDC" class="cite xref">OIDC</a>]</span> and <span>[<a href="#ISO29100" class="cite xref">ISO29100</a>]</span> apply.<a href="#section-3-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="symbols-and-abbreviated-terms">
+<section id="section-4">
+      <h2 id="name-symbols-and-abbreviated-ter">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-symbols-and-abbreviated-ter" class="section-name selfRef">Symbols and Abbreviated terms</a>
+      </h2>
+<p id="section-4-1"><strong>API</strong> – Application Programming Interface<a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-4-2"><strong>HTTP</strong> – Hyper Text Transfer Protocol<a href="#section-4-2" class="pilcrow">¶</a></p>
+<p id="section-4-3"><strong>JAR</strong> – JWT-Secured Authorization Request<a href="#section-4-3" class="pilcrow">¶</a></p>
+<p id="section-4-4"><strong>JARM</strong> – JWT Secured Authorization Response Mode<a href="#section-4-4" class="pilcrow">¶</a></p>
+<p id="section-4-5"><strong>JWT</strong> – JSON Web Token<a href="#section-4-5" class="pilcrow">¶</a></p>
+<p id="section-4-6"><strong>JSON</strong> – JavaScript Object Notation<a href="#section-4-6" class="pilcrow">¶</a></p>
+<p id="section-4-7"><strong>OIDF</strong> – OpenID Foundation<a href="#section-4-7" class="pilcrow">¶</a></p>
+<p id="section-4-8"><strong>PAR</strong> – Pushed Authorization Requests<a href="#section-4-8" class="pilcrow">¶</a></p>
+<p id="section-4-9"><strong>PKCE</strong> – Proof Key for Code Exchange<a href="#section-4-9" class="pilcrow">¶</a></p>
+<p id="section-4-10"><strong>REST</strong> – Representational State Transfer<a href="#section-4-10" class="pilcrow">¶</a></p>
+<p id="section-4-11"><strong>TLS</strong> – Transport Layer Security<a href="#section-4-11" class="pilcrow">¶</a></p>
+<p id="section-4-12"><strong>URI</strong> – Uniform Resource Identifier<a href="#section-4-12" class="pilcrow">¶</a></p>
+<p id="section-4-13"><strong>URL</strong> – Uniform Resource Locator<a href="#section-4-13" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="message-signing-profile">
+<section id="section-5">
+      <h2 id="name-message-signing-profile">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-message-signing-profile" class="section-name selfRef">Message signing profile</a>
+      </h2>
+<p id="section-5-1">OIDF FAPI 2.0 is an API security profile based on the OAuth 2.0 Authorization
+Framework <span>[<a href="#RFC6749" class="cite xref">RFC6749</a>]</span>. This Message Signing Profile aims to reach the security goals
+laid out in the Attacker Model <span>[<a href="#attackermodel" class="cite xref">attackermodel</a>]</span> plus the non-repudiation goals listed below.<a href="#section-5-1" class="pilcrow">¶</a></p>
+<p id="section-5-2">All provisions of the <span>[<a href="#FAPI2_Security_Profile" class="cite xref">FAPI2_Security_Profile</a>]</span> apply to the Message Signing Profile
+as well, with the extensions described in the following.<a href="#section-5-2" class="pilcrow">¶</a></p>
+<div id="profile">
+<section id="section-5.1">
+        <h3 id="name-profile">
+<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-profile" class="section-name selfRef">Profile</a>
+        </h3>
+<p id="section-5.1-1">In addition to the technologies used in the <span>[<a href="#FAPI2_Security_Profile" class="cite xref">FAPI2_Security_Profile</a>]</span>, the
+following standards are used in this profile:<a href="#section-5.1-1" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-5.1-2.1">OAuth 2.0 JWT Secured Authorization Request (JAR) <span>[<a href="#RFC9101" class="cite xref">RFC9101</a>]</span> for signing authorization requests<a href="#section-5.1-2.1" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-5.1-2.2">JWT Secured Authorization Response Mode for OAuth 2.0 <span>[<a href="#JARM" class="cite xref">JARM</a>]</span> for signing authorization responses<a href="#section-5.1-2.2" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-5.1-2.3">OAuth 2.0 Token Introspection <span>[<a href="#RFC7662" class="cite xref">RFC7662</a>]</span> with <span>[<a href="#RFC9701" class="cite xref">RFC9701</a>]</span> for signing introspection responses<a href="#section-5.1-2.3" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-5.1-3">We understand that some ecosystems may only desire to implement 1, 2 or 3 of the above, it is therefore
+anticipated that a piece of software will be able to conform to each of the methods separately, i.e. there
+will be separate conformance testing options for each of the following:<a href="#section-5.1-3" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-5.1-4.1">Signed authorization requests<a href="#section-5.1-4.1" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-5.1-4.2">Signed authorization responses<a href="#section-5.1-4.2" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-5.1-4.3">Signed introspection responses<a href="#section-5.1-4.3" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+</div>
+<div id="non-repudiation">
+<section id="section-5.2">
+        <h3 id="name-non-repudiation">
+<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-non-repudiation" class="section-name selfRef">Non-repudiation</a>
+        </h3>
+<p id="section-5.2-1">Beyond what is captured by the security goals and the attacker model in
+<span>[<a href="#attackermodel" class="cite xref">attackermodel</a>]</span>, parties could try to deny having sent a particular message,
+for example, a payment request. For this purpose, non-repudiation is needed.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
+<p id="section-5.2-2">In the context of this specification, non-repudiation refers to the assurance that the owner of
+a signature key pair that was capable of generating an existing signature corresponding to certain
+data cannot convincingly deny having signed the data (<span>[<a href="#NIST.SP.800-133" class="cite xref">NIST.SP.800-133</a>]</span>).<a href="#section-5.2-2" class="pilcrow">¶</a></p>
+<p id="section-5.2-3">This is usually achieved by providing application-level signatures that can be
+stored together with the payload and meaningful metadata of a request or
+response.<a href="#section-5.2-3" class="pilcrow">¶</a></p>
+<p id="section-5.2-4">The following messages are affected by this specification:<a href="#section-5.2-4" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-5.2-5.1">NR1: pushed authorization requests<a href="#section-5.2-5.1" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-5.2-5.2">NR2: authorization requests (front-channel)<a href="#section-5.2-5.2" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-5.2-5.3">NR3: authorization responses (front-channel)<br><a href="#section-5.2-5.3" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-5.2-5.4">NR4: introspection responses<br><a href="#section-5.2-5.4" class="pilcrow">¶</a>
+</li>
+          <li class="compact" id="section-5.2-5.5">NR5: ID tokens<a href="#section-5.2-5.5" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+</div>
+<div id="signing-authorization-requests">
+<section id="section-5.3">
+        <h3 id="name-signing-authorization-reque">
+<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-signing-authorization-reque" class="section-name selfRef">Signing authorization requests</a>
+        </h3>
+<p id="section-5.3-1">To support non-repudiation for NR1, pushed authorization requests can be signed.
+Because FAPI2 uses <span>[<a href="#RFC9126" class="cite xref">RFC9126</a>]</span>, NR2 is achieved by default when the pushed authorization request
+is signed.<a href="#section-5.3-1" class="pilcrow">¶</a></p>
+<div id="requirements-for-authorization-servers">
+<section id="section-5.3.1">
+          <h4 id="name-requirements-for-authorizat">
+<a href="#section-5.3.1" class="section-number selfRef">5.3.1. </a><a href="#name-requirements-for-authorizat" class="section-name selfRef">Requirements for authorization servers</a>
+          </h4>
+<p id="section-5.3.1-1">Authorization servers implementing FAPI2 authorization request signing<a href="#section-5.3.1-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-5.3.1-2">
+<li id="section-5.3.1-2.1">shall support, require use of, and verify signed request objects according to JAR
+<span>[<a href="#RFC9101" class="cite xref">RFC9101</a>]</span> at the PAR endpoint <span>[<a href="#RFC9126" class="cite xref">RFC9126</a>]</span>;<a href="#section-5.3.1-2.1" class="pilcrow">¶</a>
+</li>
+            <li id="section-5.3.1-2.2">shall require the aud claim in the request object to be, or to be an array containing, the authorization server's issuer identifier URL;<a href="#section-5.3.1-2.2" class="pilcrow">¶</a>
+</li>
+            <li id="section-5.3.1-2.3">shall require the request object to contain an <code>nbf</code> claim that is no longer than 60 minutes in the past; and<a href="#section-5.3.1-2.3" class="pilcrow">¶</a>
+</li>
+            <li id="section-5.3.1-2.4">shall require the request object to contain an <code>exp</code> claim that has a lifetime of no longer than 60 minutes after the <code>nbf</code> claim;<a href="#section-5.3.1-2.4" class="pilcrow">¶</a>
+</li>
+            <li id="section-5.3.1-2.5">shall accept request objects with <code>typ</code> header parameter with a value <code>oauth-authz-req+jwt</code>.<a href="#section-5.3.1-2.5" class="pilcrow">¶</a>
+</li>
+          </ol>
+</section>
+</div>
+<div id="requirements-for-clients">
+<section id="section-5.3.2">
+          <h4 id="name-requirements-for-clients">
+<a href="#section-5.3.2" class="section-number selfRef">5.3.2. </a><a href="#name-requirements-for-clients" class="section-name selfRef">Requirements for clients</a>
+          </h4>
+<p id="section-5.3.2-1">Clients implementing FAPI2 authorization request signing<a href="#section-5.3.2-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-5.3.2-2">
+<li id="section-5.3.2-2.1">shall send all authorization parameters to the PAR endpoint <span>[<a href="#RFC9126" class="cite xref">RFC9126</a>]</span> in a JAR
+<span>[<a href="#RFC9101" class="cite xref">RFC9101</a>]</span> signed requested object;<a href="#section-5.3.2-2.1" class="pilcrow">¶</a>
+</li>
+            <li id="section-5.3.2-2.2">shall send the <code>aud</code> claim in the request object as the authorization server's issuer identifier URL;<a href="#section-5.3.2-2.2" class="pilcrow">¶</a>
+</li>
+            <li id="section-5.3.2-2.3">shall send a <code>nbf</code> claim in the request object;<a href="#section-5.3.2-2.3" class="pilcrow">¶</a>
+</li>
+            <li id="section-5.3.2-2.4">shall send an <code>exp</code> claim in the request object that has a lifetime of no longer than 60 minutes;<a href="#section-5.3.2-2.4" class="pilcrow">¶</a>
+</li>
+            <li id="section-5.3.2-2.5">should send a <code>typ</code> header parameter with a value <code>oauth-authz-req+jwt</code>.<a href="#section-5.3.2-2.5" class="pilcrow">¶</a>
+</li>
+          </ol>
+</section>
+</div>
+<div id="client-metadata">
+<section id="section-5.3.3">
+          <h4 id="name-client-metadata">
+<a href="#section-5.3.3" class="section-number selfRef">5.3.3. </a><a href="#name-client-metadata" class="section-name selfRef">Client metadata</a>
+          </h4>
+<p id="section-5.3.3-1">The Dynamic Client Registration Protocol <span>[<a href="#RFC7591" class="cite xref">RFC7591</a>]</span> defines an API
+for dynamically registering OAuth 2.0 client metadata with authorization servers.
+The metadata defined by <span>[<a href="#RFC7591" class="cite xref">RFC7591</a>]</span>, and registered extensions to it,
+also imply a general data model for clients that is useful for authorization server implementations
+even when the dynamic client registration protocol isn't in play.
+Such implementations will typically have some sort of user interface available for managing client configuration.<a href="#section-5.3.3-1" class="pilcrow">¶</a></p>
+<p id="section-5.3.3-2">The following client metadata parameter is introduced by this specification:<a href="#section-5.3.3-2" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-5.3.3-3.1">
+              <p id="section-5.3.3-3.1.1"><code>response_modes</code>:<a href="#section-5.3.3-3.1.1" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-5.3.3-3.1.2.1">OPTIONAL. A JSON array of strings containing the list of response modes that
+the client may use. If omitted, the default is that the client may use any of
+the response modes supported by the authorization server.<a href="#section-5.3.3-3.1.2.1" class="pilcrow">¶</a>
+</li>
+              </ul>
+</li>
+          </ul>
+</section>
+</div>
+</section>
+</div>
+<div id="signing-authorization-responses">
+<section id="section-5.4">
+        <h3 id="name-signing-authorization-respo">
+<a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-signing-authorization-respo" class="section-name selfRef">Signing authorization responses</a>
+        </h3>
+<p id="section-5.4-1">To support non-repudiation for NR3, authorization responses can be signed.<a href="#section-5.4-1" class="pilcrow">¶</a></p>
+<div id="requirements-for-authorization-servers-1">
+<section id="section-5.4.1">
+          <h4 id="name-requirements-for-authorizati">
+<a href="#section-5.4.1" class="section-number selfRef">5.4.1. </a><a href="#name-requirements-for-authorizati" class="section-name selfRef">Requirements for authorization servers</a>
+          </h4>
+<p id="section-5.4.1-1">Authorization servers implementing FAPI2 authorization response signing<a href="#section-5.4.1-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-5.4.1-2">
+<li id="section-5.4.1-2.1">shall support, require use of, and issue signed authorization responses via JWT Secured Authorization
+Response Mode for OAuth 2.0 <span>[<a href="#JARM" class="cite xref">JARM</a>]</span>.<a href="#section-5.4.1-2.1" class="pilcrow">¶</a>
+</li>
+          </ol>
+<p id="section-5.4.1-3"><strong>NOTE</strong>: When using <span>[<a href="#JARM" class="cite xref">JARM</a>]</span> an authorization server should only include the iss authorization response
+parameter defined by <span>[<a href="#RFC9207" class="cite xref">RFC9207</a>]</span> inside the JWT. This is because <span>[<a href="#RFC9207" class="cite xref">RFC9207</a>]</span> defines <code>iss</code>
+to be an authorization response parameter, and <span>[<a href="#JARM" class="cite xref">JARM</a>]</span> Section 4.1 requires all authorization
+response parameters to be inside the JWT.<a href="#section-5.4.1-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="requirements-for-clients-1">
+<section id="section-5.4.2">
+          <h4 id="name-requirements-for-clients-2">
+<a href="#section-5.4.2" class="section-number selfRef">5.4.2. </a><a href="#name-requirements-for-clients-2" class="section-name selfRef">Requirements for clients</a>
+          </h4>
+<p id="section-5.4.2-1">Clients implementing FAPI2 authorization response signing<a href="#section-5.4.2-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-5.4.2-2">
+<li id="section-5.4.2-2.1">shall set the <code>response_mode</code> to <code>jwt</code> in the authorization request as defined in <span>[<a href="#JARM" class="cite xref">JARM</a>]</span>; and<a href="#section-5.4.2-2.1" class="pilcrow">¶</a>
+</li>
+            <li id="section-5.4.2-2.2">shall verify signed authorization responses according to <span>[<a href="#JARM" class="cite xref">JARM</a>]</span>.<a href="#section-5.4.2-2.2" class="pilcrow">¶</a>
+</li>
+          </ol>
+</section>
+</div>
+</section>
+</div>
+<div id="signing-introspection-responses">
+<section id="section-5.5">
+        <h3 id="name-signing-introspection-respo">
+<a href="#section-5.5" class="section-number selfRef">5.5. </a><a href="#name-signing-introspection-respo" class="section-name selfRef">Signing introspection responses</a>
+        </h3>
+<p id="section-5.5-1">To support non-repudiation for NR4, introspection responses can be signed.<a href="#section-5.5-1" class="pilcrow">¶</a></p>
+<div id="requirements-for-authorization-servers-2">
+<section id="section-5.5.1">
+          <h4 id="name-requirements-for-authorizatio">
+<a href="#section-5.5.1" class="section-number selfRef">5.5.1. </a><a href="#name-requirements-for-authorizatio" class="section-name selfRef">Requirements for authorization servers</a>
+          </h4>
+<p id="section-5.5.1-1">Authorization servers implementing FAPI2 introspection response signing<a href="#section-5.5.1-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-5.5.1-2">
+<li id="section-5.5.1-2.1">shall sign introspection responses that are issued in JWT format according to <span>[<a href="#RFC9701" class="cite xref">RFC9701</a>]</span><a href="#section-5.5.1-2.1" class="pilcrow">¶</a>
+</li>
+          </ol>
+</section>
+</div>
+<div id="requirements-for-clients-2">
+<section id="section-5.5.2">
+          <h4 id="name-requirements-for-clients-3">
+<a href="#section-5.5.2" class="section-number selfRef">5.5.2. </a><a href="#name-requirements-for-clients-3" class="section-name selfRef">Requirements for clients</a>
+          </h4>
+<p id="section-5.5.2-1">Clients implementing FAPI2 introspection response signing<a href="#section-5.5.2-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-5.5.2-2">
+<li id="section-5.5.2-2.1">shall request signed token introspection responses according to <span>[<a href="#RFC9701" class="cite xref">RFC9701</a>]</span>; and<a href="#section-5.5.2-2.1" class="pilcrow">¶</a>
+</li>
+            <li id="section-5.5.2-2.2">shall verify the signed token introspection responses.<a href="#section-5.5.2-2.2" class="pilcrow">¶</a>
+</li>
+          </ol>
+</section>
+</div>
+</section>
+</div>
+<div id="signing-id-tokens">
+<section id="section-5.6">
+        <h3 id="name-signing-id-tokens">
+<a href="#section-5.6" class="section-number selfRef">5.6. </a><a href="#name-signing-id-tokens" class="section-name selfRef">Signing ID tokens</a>
+        </h3>
+<p id="section-5.6-1">To support non-repudiation for NR5, signed ID tokens are used.<a href="#section-5.6-1" class="pilcrow">¶</a></p>
+<div id="requirements-for-authorization-servers-3">
+<section id="section-5.6.1">
+          <h4 id="name-requirements-for-authorization">
+<a href="#section-5.6.1" class="section-number selfRef">5.6.1. </a><a href="#name-requirements-for-authorization" class="section-name selfRef">Requirements for authorization servers</a>
+          </h4>
+<p id="section-5.6.1-1">No additional requirements.<a href="#section-5.6.1-1" class="pilcrow">¶</a></p>
+<p id="section-5.6.1-2">Note: Authorization servers implementing FAPI2 are already required to sign ID tokens as specified in section 5.4.1 in the <span>[<a href="#FAPI2_Security_Profile" class="cite xref">FAPI2_Security_Profile</a>]</span>.<a href="#section-5.6.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="requirements-for-clients-3">
+<section id="section-5.6.2">
+          <h4 id="name-requirements-for-clients-4">
+<a href="#section-5.6.2" class="section-number selfRef">5.6.2. </a><a href="#name-requirements-for-clients-4" class="section-name selfRef">Requirements for clients</a>
+          </h4>
+<p id="section-5.6.2-1">Clients requesting and receiving ID tokens<a href="#section-5.6.2-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-5.6.2-2">
+<li id="section-5.6.2-2.1">shall verify the signature of the signed ID token received.<a href="#section-5.6.2-2.1" class="pilcrow">¶</a>
+</li>
+          </ol>
+</section>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="security-considerations">
+<section id="section-6">
+      <h2 id="name-security-considerations">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-security-considerations" class="section-name selfRef">Security considerations</a>
+      </h2>
+<div id="authorization-response-encryption">
+<section id="section-6.1">
+        <h3 id="name-authorization-response-encr">
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-authorization-response-encr" class="section-name selfRef">Authorization response encryption</a>
+        </h3>
+<p id="section-6.1-1">In FAPI2, there is no confidential information in the authorization response, hence encryption of the authorization response is not required for the purposes of security or confidentiality. In addition, to achieve greater interoperability, it is not recommended to use encryption in this case.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.1-2">Usage of PKCE in FAPI 2 provides protection for code leakage described in Section 5.4 of <span>[<a href="#JARM" class="cite xref">JARM</a>]</span>.<a href="#section-6.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="confusion-between-resource-servers-and-clients-in-introspection-request">
+<section id="section-6.2">
+        <h3 id="name-confusion-between-resource-">
+<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-confusion-between-resource-" class="section-name selfRef">Confusion between resource servers and clients in introspection request</a>
+        </h3>
+<p id="section-6.2-1">In <span>[<a href="#RFC9701" class="cite xref">RFC9701</a>]</span>, the resource server accessing
+the introspection endpoint is seen in the role of a client towards the
+authorization server that is providing the introspection endpoint. A malicious
+client (that is not a resource server) could attempt to call the introspection
+endpoint directly, and thus gather information about an access token to which it
+is not supposed to have access. This may, for example, leak secrets including,
+if the access token was leaked or stolen, personal information about an
+end-user.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.2-2">The authorization server therefore must ensure that the resource server is not
+confused with a regular client that is not supposed to call the introspection
+endpoint, and that the resource server has the necessary authorization to access
+the information associated with the access token.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="non-repudiation-limited-to-individual-messages">
+<section id="section-6.3">
+        <h3 id="name-non-repudiation-limited-to-">
+<a href="#section-6.3" class="section-number selfRef">6.3. </a><a href="#name-non-repudiation-limited-to-" class="section-name selfRef">Non-repudiation limited to individual messages</a>
+        </h3>
+<p id="section-6.3-1">It is important to note that while this specification provides mechanisms for non-repudiation for
+individual messages, it does not provide non-repudiation guarantees for a sequence of messages.<a href="#section-6.3-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="non-repudiation-not-provided-for-front-channel-authorization-requests">
+<section id="section-6.4">
+        <h3 id="name-non-repudiation-not-provide">
+<a href="#section-6.4" class="section-number selfRef">6.4. </a><a href="#name-non-repudiation-not-provide" class="section-name selfRef">Non-repudiation not provided for front channel authorization requests</a>
+        </h3>
+<p id="section-6.4-1">While only a small amount of information is present in a <span>[<a href="#FAPI2_Security_Profile" class="cite xref">FAPI2_Security_Profile</a>]</span> front channel
+authorization request, it is important to note that non-repudiation is not provided for this message.<a href="#section-6.4-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="difficulty-in-linking-a-signed-message-to-a-real-world-identity">
+<section id="section-6.5">
+        <h3 id="name-difficulty-in-linking-a-sig">
+<a href="#section-6.5" class="section-number selfRef">6.5. </a><a href="#name-difficulty-in-linking-a-sig" class="section-name selfRef">Difficulty in linking a signed message to a real world identity</a>
+        </h3>
+<p id="section-6.5-1">This specification provides the technical means to sign messages, however proving that a specific signed response is
+linked to a specific real world end-user, or that a real world end-user initiated a specific request is outside of the
+scope of this document.<a href="#section-6.5-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="the-value-of-jarm-for-non-repudiation">
+<section id="section-6.6">
+        <h3 id="name-the-value-of-jarm-for-non-r">
+<a href="#section-6.6" class="section-number selfRef">6.6. </a><a href="#name-the-value-of-jarm-for-non-r" class="section-name selfRef">The value of JARM for non-repudiation</a>
+        </h3>
+<p id="section-6.6-1">The values signed in a JARM response may be of limited value for non-repudiation as the values are artifacts
+of the OAuth flow (e.g. code and state) rather than real world values (e.g. account number and amount). However JARM
+is still useful in providing message integrity to the authorization response.<a href="#section-6.6-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="privacy-considerations">
+<section id="section-7">
+      <h2 id="name-privacy-considerations">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-privacy-considerations" class="section-name selfRef">Privacy considerations</a>
+      </h2>
+<p id="section-7-1">In addition to the privacy considerations detailed in <span>[<a href="#FAPI2_Security_Profile" class="cite xref">FAPI2_Security_Profile</a>]</span> implementers should consider
+the privacy implications of storing messages for the purpose of non-repudiation.<a href="#section-7-1" class="pilcrow">¶</a></p>
+<p id="section-7-2">Such messages may well contain personally identifiable information and implementers should evaluate
+whether such messages need to be stored. If they are stored then adequate access controls must be
+put in place to protect that data. Such controls should follow data minimisation principles and ensure that
+there are tamper-proof audit logs.<a href="#section-7-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="iana-considerations">
+<section id="section-8">
+      <h2 id="name-iana-considerations">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA considerations</a>
+      </h2>
+<div id="oauth-dynamic-client-registration-metadata-registration">
+<section id="section-8.1">
+        <h3 id="name-oauth-dynamic-client-regist">
+<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-oauth-dynamic-client-regist" class="section-name selfRef">OAuth dynamic client registration metadata registration</a>
+        </h3>
+<p id="section-8.1-1">This specification requests registration of the following client metadata
+definitions in the IANA "OAuth Dynamic Client Registration Metadata" registry
+established by <span>[<a href="#RFC7591" class="cite xref">RFC7591</a>]</span>:<a href="#section-8.1-1" class="pilcrow">¶</a></p>
+<div id="registry-contents">
+<section id="section-8.1.1">
+          <h4 id="name-registry-contents">
+<a href="#section-8.1.1" class="section-number selfRef">8.1.1. </a><a href="#name-registry-contents" class="section-name selfRef">Registry contents</a>
+          </h4>
+<ul class="compact">
+<li class="compact" id="section-8.1.1-1.1">Client Metadata Name: <code>response_modes</code><a href="#section-8.1.1-1.1" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-8.1.1-1.2">Client Metadata Description: Array of the response modes that the client may use<a href="#section-8.1.1-1.2" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-8.1.1-1.3">Change Controller: IESG<a href="#section-8.1.1-1.3" class="pilcrow">¶</a>
+</li>
+            <li class="compact" id="section-8.1.1-1.4">Specification Document(s): <a href="#client-metadata" class="auto internal xref">Section 5.3.3</a> of this specification<a href="#section-8.1.1-1.4" class="pilcrow">¶</a>
+</li>
+          </ul>
+</section>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="acknowledgements">
+<section id="section-9">
+      <h2 id="name-acknowledgements">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+      </h2>
+<p id="section-9-1">This specification was developed by the OpenID FAPI Working Group.<a href="#section-9-1" class="pilcrow">¶</a></p>
+<p id="section-9-2">We would like to thank Takahiko Kawasaki, Filip Skokan, Nat Sakimura, Dima Postnikov, Brian Campbell, Ralph Bragg, Justin Richer and Lukasz Jaromin for their valuable feedback and contributions that helped to evolve this specification.<a href="#section-9-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<section id="section-10">
+      <h2 id="name-normative-references-2">
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-normative-references-2" class="section-name selfRef">Normative References</a>
+      </h2>
+<dl class="references">
+<dt id="FAPI2_Security_Profile">[FAPI2_Security_Profile]</dt>
+      <dd>
+<span class="refAuthor">Fett, D.</span>, <span class="refAuthor">Tonge, D.</span>, and <span class="refAuthor">J. Heenan</span>, <span class="refTitle">"FAPI 2.0 Security Profile"</span>, <time datetime="2025-02-22" class="refDate">22 February 2025</time>, <span>&lt;<a href="https://openid.net/specs/fapi-security-profile-2_0.html">https://openid.net/specs/fapi-security-profile-2_0.html</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="ISO29100">[ISO29100]</dt>
+      <dd>
+<span class="refAuthor">ISO/IEC</span>, <span class="refTitle">"ISO/IEC 29100 Information technology – Security techniques – Privacy framework"</span>, <span>&lt;<a href="https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html#:~:text=IEC%2029100%3A2011-,EN,-%2D%20FR">https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html#:~:text=IEC%2029100%3A2011-,EN,-%2D%20FR</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="JARM">[JARM]</dt>
+      <dd>
+<span class="refAuthor">Lodderstedt, T.</span> and <span class="refAuthor">B. Campbell</span>, <span class="refTitle">"JWT Secured Authorization Response Mode for OAuth 2.0 (JARM)"</span>, <time datetime="2022-11-09" class="refDate">9 November 2022</time>, <span>&lt;<a href="https://openid.net/specs/oauth-v2-jarm-final.html">https://openid.net/specs/oauth-v2-jarm-final.html</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="NIST.SP.800-133">[NIST.SP.800-133]</dt>
+      <dd>
+<span class="refAuthor">Barker, E.</span> and <span class="refAuthor">A. Roginsky</span>, <span class="refTitle">"NIST Special Publication 800-133"</span>, <time datetime="2019-07-23" class="refDate">23 July 2019</time>, <span>&lt;<a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-133.pdf">https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-133.pdf</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="OIDC">[OIDC]</dt>
+      <dd>
+<span class="refAuthor">Sakimura, N.</span>, <span class="refAuthor">Bradley, J.</span>, <span class="refAuthor">Jones, M.</span>, <span class="refAuthor">de Medeiros, B.</span>, and <span class="refAuthor">C. Mortimore</span>, <span class="refTitle">"OpenID Connect Core 1.0 incorporating errata set 2"</span>, <time datetime="2014-11-08" class="refDate">8 November 2014</time>, <span>&lt;<a href="http://openid.net/specs/openid-connect-core-1_0.html">http://openid.net/specs/openid-connect-core-1_0.html</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC6749">[RFC6749]</dt>
+      <dd>
+<span class="refAuthor">Hardt, D., Ed.</span>, <span class="refTitle">"The OAuth 2.0 Authorization Framework"</span>, <span class="seriesInfo">RFC 6749</span>, <span class="seriesInfo">DOI 10.17487/RFC6749</span>, <time datetime="2012-10" class="refDate">October 2012</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc6749">https://www.rfc-editor.org/info/rfc6749</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC6750">[RFC6750]</dt>
+      <dd>
+<span class="refAuthor">Jones, M.</span> and <span class="refAuthor">D. Hardt</span>, <span class="refTitle">"The OAuth 2.0 Authorization Framework: Bearer Token Usage"</span>, <span class="seriesInfo">RFC 6750</span>, <span class="seriesInfo">DOI 10.17487/RFC6750</span>, <time datetime="2012-10" class="refDate">October 2012</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc6750">https://www.rfc-editor.org/info/rfc6750</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7636">[RFC7636]</dt>
+      <dd>
+<span class="refAuthor">Sakimura, N., Ed.</span>, <span class="refAuthor">Bradley, J.</span>, and <span class="refAuthor">N. Agarwal</span>, <span class="refTitle">"Proof Key for Code Exchange by OAuth Public Clients"</span>, <span class="seriesInfo">RFC 7636</span>, <span class="seriesInfo">DOI 10.17487/RFC7636</span>, <time datetime="2015-09" class="refDate">September 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7636">https://www.rfc-editor.org/info/rfc7636</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7662">[RFC7662]</dt>
+      <dd>
+<span class="refAuthor">Richer, J., Ed.</span>, <span class="refTitle">"OAuth 2.0 Token Introspection"</span>, <span class="seriesInfo">RFC 7662</span>, <span class="seriesInfo">DOI 10.17487/RFC7662</span>, <time datetime="2015-10" class="refDate">October 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7662">https://www.rfc-editor.org/info/rfc7662</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9101">[RFC9101]</dt>
+      <dd>
+<span class="refAuthor">Sakimura, N.</span>, <span class="refAuthor">Bradley, J.</span>, and <span class="refAuthor">M. Jones</span>, <span class="refTitle">"The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR)"</span>, <span class="seriesInfo">RFC 9101</span>, <span class="seriesInfo">DOI 10.17487/RFC9101</span>, <time datetime="2021-08" class="refDate">August 2021</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9101">https://www.rfc-editor.org/info/rfc9101</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9126">[RFC9126]</dt>
+      <dd>
+<span class="refAuthor">Lodderstedt, T.</span>, <span class="refAuthor">Campbell, B.</span>, <span class="refAuthor">Sakimura, N.</span>, <span class="refAuthor">Tonge, D.</span>, and <span class="refAuthor">F. Skokan</span>, <span class="refTitle">"OAuth 2.0 Pushed Authorization Requests"</span>, <span class="seriesInfo">RFC 9126</span>, <span class="seriesInfo">DOI 10.17487/RFC9126</span>, <time datetime="2021-09" class="refDate">September 2021</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9126">https://www.rfc-editor.org/info/rfc9126</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9207">[RFC9207]</dt>
+      <dd>
+<span class="refAuthor">Meyer zu Selhausen, K.</span> and <span class="refAuthor">D. Fett</span>, <span class="refTitle">"OAuth 2.0 Authorization Server Issuer Identification"</span>, <span class="seriesInfo">RFC 9207</span>, <span class="seriesInfo">DOI 10.17487/RFC9207</span>, <time datetime="2022-03" class="refDate">March 2022</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9207">https://www.rfc-editor.org/info/rfc9207</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9701">[RFC9701]</dt>
+      <dd>
+<span class="refAuthor">Lodderstedt, T., Ed.</span> and <span class="refAuthor">V. Dzhuvinov</span>, <span class="refTitle">"JSON Web Token (JWT) Response for OAuth Token Introspection"</span>, <span class="seriesInfo">RFC 9701</span>, <span class="seriesInfo">DOI 10.17487/RFC9701</span>, <time datetime="2025-01" class="refDate">January 2025</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9701">https://www.rfc-editor.org/info/rfc9701</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="attackermodel">[attackermodel]</dt>
+    <dd>
+<span class="refAuthor">Fett, D.</span>, <span class="refTitle">"FAPI 2.0 Attacker Model"</span>, <time datetime="2025-02-22" class="refDate">22 February 2025</time>, <span>&lt;<a href="https://openid.net/specs/fapi-attacker-model-2_0.html">https://openid.net/specs/fapi-attacker-model-2_0.html</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<section id="section-11">
+      <h2 id="name-informative-references">
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+      </h2>
+<dl class="references">
+<dt id="FAPI2MSANALYSIS">[FAPI2MSANALYSIS]</dt>
+      <dd>
+<span class="refAuthor">Hosseyni, P.</span>, <span class="refAuthor">Kuesters, R.</span>, and <span class="refAuthor">T. Würtele</span>, <span class="refTitle">"Formal security analysis of the OpenID FAPI 2.0 Security Profile with FAPI 2.0 Message Signing, FAPI-CIBA, Dynamic Client Registration and Management"</span>, <time datetime="2024-10-04" class="refDate">4 October 2024</time>, <span>&lt;<a href="http://dx.doi.org/10.18419/opus-13698">http://dx.doi.org/10.18419/opus-13698</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="ISODIR2">[ISODIR2]</dt>
+      <dd>
+<span class="refAuthor">ISO/IEC</span>, <span class="refTitle">"ISO/IEC Directives, Part 2 - Principles and rules for the structure and drafting of ISO and IEC documents"</span>, <span>&lt;<a href="https://www.iso.org/sites/directives/current/part2/index.xhtml">https://www.iso.org/sites/directives/current/part2/index.xhtml</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7591">[RFC7591]</dt>
+    <dd>
+<span class="refAuthor">Richer, J., Ed.</span>, <span class="refAuthor">Jones, M.</span>, <span class="refAuthor">Bradley, J.</span>, <span class="refAuthor">Machulak, M.</span>, and <span class="refAuthor">P. Hunt</span>, <span class="refTitle">"OAuth 2.0 Dynamic Client Registration Protocol"</span>, <span class="seriesInfo">RFC 7591</span>, <span class="seriesInfo">DOI 10.17487/RFC7591</span>, <time datetime="2015-07" class="refDate">July 2015</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7591">https://www.rfc-editor.org/info/rfc7591</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<div id="notices">
+<section id="appendix-A">
+      <h2 id="name-notices">
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-notices" class="section-name selfRef">Notices</a>
+      </h2>
+<p id="appendix-A-1">Copyright (c) 2025 The OpenID Foundation.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2">The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
+or other interested party a non-exclusive, royalty free, worldwide copyright license to
+reproduce, prepare derivative works from, distribute, perform and display, this
+Implementers Draft, Final Specification, or Final Specification Incorporating Errata
+Corrections solely for the purposes of (i) developing specifications, and (ii)
+implementing Implementers Drafts, Final Specifications, and Final Specification
+Incorporating Errata Corrections based on such documents, provided that attribution
+be made to the OIDF as the source of the material, but that such attribution does not
+indicate an endorsement by the OIDF.<a href="#appendix-A-2" class="pilcrow">¶</a></p>
+<p id="appendix-A-3">The technology described in this specification was made available from contributions
+from various sources, including members of the OpenID Foundation and others.
+Although the OpenID Foundation has taken steps to help ensure that the technology
+is available for distribution, it takes no position regarding the validity or scope of any
+intellectual property or other rights that might be claimed to pertain to the
+implementation or use of the technology described in this specification or the extent
+to which any license under such rights might or might not be available; neither does it
+represent that it has made any independent effort to identify any such rights. The
+OpenID Foundation and the contributors to this specification make no (and hereby
+expressly disclaim any) warranties (express, implied, or otherwise), including implied
+warranties of merchantability, non-infringement, fitness for a particular purpose, or
+title, related to this specification, and the entire risk as to implementing this
+specification is assumed by the implementer. The OpenID Intellectual Property
+Rights policy (found at openid.net) requires contributors to offer a patent promise not
+to assert certain patent claims against other contributors and against implementers.
+OpenID invites any interested party to bring to its attention any copyrights, patents,
+patent applications, or other proprietary rights that may cover technology that may be
+required to practice this specification.<a href="#appendix-A-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="authors-addresses">
+<section id="appendix-B">
+      <h2 id="name-authors-addresses">
+<a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
+      </h2>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Dave Tonge</span></div>
+<div dir="auto" class="left"><span class="org">Moneyhub Financial Technology</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:dave@tonge.org" class="email">dave@tonge.org</a>
+</div>
+</address>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Daniel Fett</span></div>
+<div dir="auto" class="left"><span class="org">Authlete</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:mail@danielfett.de" class="email">mail@danielfett.de</a>
+</div>
+</address>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Joseph Heenan</span></div>
+<div dir="auto" class="left"><span class="org">Authlete</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:joseph@authlete.com" class="email">joseph@authlete.com</a>
+</div>
+</address>
+</section>
+</div>
+<script>const toc = document.getElementById("toc");
+toc.querySelector("h2").addEventListener("click", e => {
+  toc.classList.toggle("active");
+});
+toc.querySelector("nav").addEventListener("click", e => {
+  toc.classList.remove("active");
+});
+</script>
+</body>
+</html>

--- a/fapi/fapi-message-signing-2_0-final.md
+++ b/fapi/fapi-message-signing-2_0-final.md
@@ -1,0 +1,495 @@
+%%%
+title = "FAPI 2.0 Message Signing"
+abbrev = "fapi-message-signing-2"
+ipr = "none"
+workgroup = "fapi"
+keyword = ["security", "openid"]
+
+[seriesInfo]
+name = "Internet-Draft"
+value = "fapi-message-signing-2_0-02"
+status = "standard"
+
+[[author]]
+initials="D."
+surname="Tonge"
+fullname="Dave Tonge"
+organization="Moneyhub Financial Technology"
+    [author.address]
+    email = "dave@tonge.org"
+ 
+[[author]]
+initials="D."
+surname="Fett"
+fullname="Daniel Fett"
+organization="Authlete"
+    [author.address]
+    email = "mail@danielfett.de"
+
+[[author]]
+initials="J."
+surname="Heenan"
+fullname="Joseph Heenan"
+organization="Authlete"
+    [author.address]
+    email = "joseph@authlete.com"
+
+%%%
+
+.# Abstract
+
+OIDF FAPI 2.0 Message Signing is an API security profile for signing and verifying certain FAPI 2.0 Security Profile [@!FAPI2_Security_Profile] based requests and responses.
+
+.# Foreword
+
+The OpenID Foundation (OIDF) promotes, protects and nurtures the OpenID community and technologies. As a non-profit international standardizing body, it is comprised by over 160 participating entities (workgroup participant). The work of preparing implementer drafts and final international standards is carried out through OIDF workgroups in accordance with the OpenID Process. Participants interested in a subject for which a workgroup has been established have the right to be represented in that workgroup. International organizations, governmental and non-governmental, in liaison with OIDF, also take part in the work. OIDF collaborates closely with other standardizing bodies in the related fields.
+
+Final drafts adopted by the Workgroup through consensus are circulated publicly for the public review for 60 days and for the OIDF members for voting. Publication as an OIDF Standard requires approval by at least 50% of the members casting a vote. There is a possibility that some of the elements of this document may be the subject to patent rights. OIDF shall not be held responsible for identifying any or all such patent rights.
+
+
+.# Introduction
+
+OIDF FAPI 2.0 is an API security profile based on the OAuth 2.0 Authorization
+Framework [@!RFC6749]. This Message Signing Profile is part of the FAPI 2.0 family of specifications with a focus on providing interoperable support for non-repudiation across OAuth 2.0 based requests and responses. 
+
+It has been formally analysed [@FAPI2MSANALYSIS] for it's security and non-repudiation properties.
+
+.# Warning
+
+This document is not an OIDF International Standard. It is distributed for
+review and comment. It is subject to change without notice and may not be
+referred to as an International Standard.
+
+Recipients of this draft are invited to submit, with their comments,
+notification of any relevant patent rights of which they are aware and to
+provide supporting documentation.
+
+.# Notational conventions
+
+The keywords "shall", "shall not", "should", "should not", "may", and "can" in
+this document are to be interpreted as described in ISO Directive Part 2
+[@ISODIR2]. These keywords are not used as dictionary terms such that any
+occurrence of them shall be interpreted as keywords and are not to be
+interpreted with their natural language meanings.
+
+{mainmatter}
+
+# Scope
+
+This document specifies the methods for clients, authorization servers and resource servers to sign and verify messages.
+
+# Normative references
+
+The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.
+
+See Clause 8 for normative references.
+
+# Terms and definitions
+
+For the purpose of this document, the terms defined in [@!RFC6749], [@!RFC6750], [@!RFC7636], [@!OIDC] and [@!ISO29100] apply.
+
+# Symbols and Abbreviated terms
+
+**API** – Application Programming Interface
+
+**HTTP** – Hyper Text Transfer Protocol
+
+**JAR** – JWT-Secured Authorization Request
+
+**JARM** – JWT Secured Authorization Response Mode
+
+**JWT** – JSON Web Token
+
+**JSON** – JavaScript Object Notation
+
+**OIDF** – OpenID Foundation
+
+**PAR** – Pushed Authorization Requests
+
+**PKCE** – Proof Key for Code Exchange
+
+**REST** – Representational State Transfer
+
+**TLS** – Transport Layer Security
+
+**URI** – Uniform Resource Identifier
+
+**URL** – Uniform Resource Locator
+
+# Message signing profile
+
+OIDF FAPI 2.0 is an API security profile based on the OAuth 2.0 Authorization
+Framework [@!RFC6749]. This Message Signing Profile aims to reach the security goals
+laid out in the Attacker Model [@!attackermodel] plus the non-repudiation goals listed below.
+
+All provisions of the [@!FAPI2_Security_Profile] apply to the Message Signing Profile
+as well, with the extensions described in the following.
+
+
+## Profile
+
+In addition to the technologies used in the [@!FAPI2_Security_Profile], the
+following standards are used in this profile:
+
+  * OAuth 2.0 JWT Secured Authorization Request (JAR) [@!RFC9101] for signing authorization requests
+  * JWT Secured Authorization Response Mode for OAuth 2.0 [@!JARM] for signing authorization responses 
+  * OAuth 2.0 Token Introspection [@!RFC7662] with [@!RFC9701] for signing introspection responses
+
+We understand that some ecosystems may only desire to implement 1, 2 or 3 of the above, it is therefore
+anticipated that a piece of software will be able to conform to each of the methods separately, i.e. there
+will be separate conformance testing options for each of the following:
+
+ * Signed authorization requests
+ * Signed authorization responses
+ * Signed introspection responses 
+
+
+## Non-repudiation
+
+Beyond what is captured by the security goals and the attacker model in
+[@!attackermodel], parties could try to deny having sent a particular message,
+for example, a payment request. For this purpose, non-repudiation is needed.
+
+In the context of this specification, non-repudiation refers to the assurance that the owner of 
+a signature key pair that was capable of generating an existing signature corresponding to certain 
+data cannot convincingly deny having signed the data ([@!NIST.SP.800-133]).
+
+This is usually achieved by providing application-level signatures that can be
+stored together with the payload and meaningful metadata of a request or
+response. 
+
+The following messages are affected by this specification:
+
+  * NR1: pushed authorization requests
+  * NR2: authorization requests (front-channel)
+  * NR3: authorization responses (front-channel)  
+  * NR4: introspection responses  
+  * NR5: ID tokens
+
+## Signing authorization requests
+
+To support non-repudiation for NR1, pushed authorization requests can be signed. 
+Because FAPI2 uses [@!RFC9126], NR2 is achieved by default when the pushed authorization request
+is signed.
+
+
+### Requirements for authorization servers
+
+Authorization servers implementing FAPI2 authorization request signing
+
+ 1. shall support, require use of, and verify signed request objects according to JAR
+    [@!RFC9101] at the PAR endpoint [@!RFC9126];
+ 2. shall require the aud claim in the request object to be, or to be an array containing, the authorization server's issuer identifier URL;
+ 3. shall require the request object to contain an `nbf` claim that is no longer than 60 minutes in the past; and
+ 4. shall require the request object to contain an `exp` claim that has a lifetime of no longer than 60 minutes after the `nbf` claim;
+ 5. shall accept request objects with `typ` header parameter with a value `oauth-authz-req+jwt`.
+
+### Requirements for clients
+
+Clients implementing FAPI2 authorization request signing
+
+ 1. shall send all authorization parameters to the PAR endpoint [@!RFC9126] in a JAR
+    [@!RFC9101] signed requested object;
+ 2. shall send the `aud` claim in the request object as the authorization server's issuer identifier URL;
+ 3. shall send a `nbf` claim in the request object;
+ 4. shall send an `exp` claim in the request object that has a lifetime of no longer than 60 minutes;
+ 5. should send a `typ` header parameter with a value `oauth-authz-req+jwt`.
+
+### Client metadata {#client-metadata}
+
+The Dynamic Client Registration Protocol [@RFC7591] defines an API
+for dynamically registering OAuth 2.0 client metadata with authorization servers.
+The metadata defined by [@RFC7591], and registered extensions to it,
+also imply a general data model for clients that is useful for authorization server implementations
+even when the dynamic client registration protocol isn't in play.
+Such implementations will typically have some sort of user interface available for managing client configuration.
+
+The following client metadata parameter is introduced by this specification:
+
+* `response_modes`: 
+    * OPTIONAL. A JSON array of strings containing the list of response modes that
+      the client may use. If omitted, the default is that the client may use any of
+      the response modes supported by the authorization server.
+ 
+## Signing authorization responses
+
+To support non-repudiation for NR3, authorization responses can be signed. 
+
+### Requirements for authorization servers
+
+Authorization servers implementing FAPI2 authorization response signing
+
+ 1. shall support, require use of, and issue signed authorization responses via JWT Secured Authorization 
+    Response Mode for OAuth 2.0 [@!JARM].
+
+**NOTE**: When using [@!JARM] an authorization server should only include the iss authorization response 
+parameter defined by [@!RFC9207] inside the JWT. This is because [@!RFC9207] defines `iss` 
+to be an authorization response parameter, and [@!JARM] Section 4.1 requires all authorization 
+response parameters to be inside the JWT.
+
+### Requirements for clients
+
+Clients implementing FAPI2 authorization response signing
+
+ 1. shall set the `response_mode` to `jwt` in the authorization request as defined in [@!JARM]; and
+ 2. shall verify signed authorization responses according to [@!JARM].
+
+
+## Signing introspection responses
+
+To support non-repudiation for NR4, introspection responses can be signed.
+
+### Requirements for authorization servers
+
+Authorization servers implementing FAPI2 introspection response signing
+
+ 1. shall sign introspection responses that are issued in JWT format according to [@!RFC9701]
+ 
+### Requirements for clients
+
+Clients implementing FAPI2 introspection response signing
+
+ 1. shall request signed token introspection responses according to [@!RFC9701]; and
+ 2. shall verify the signed token introspection responses.
+
+## Signing ID tokens
+
+To support non-repudiation for NR5, signed ID tokens are used.
+
+### Requirements for authorization servers
+
+No additional requirements. 
+
+Note: Authorization servers implementing FAPI2 are already required to sign ID tokens as specified in section 5.4.1 in the [@!FAPI2_Security_Profile].
+ 
+### Requirements for clients
+
+Clients requesting and receiving ID tokens
+
+1. shall verify the signature of the signed ID token received.
+ 
+# Security considerations
+
+## Authorization response encryption
+
+In FAPI2, there is no confidential information in the authorization response, hence encryption of the authorization response is not required for the purposes of security or confidentiality. In addition, to achieve greater interoperability, it is not recommended to use encryption in this case. 
+
+Usage of PKCE in FAPI 2 provides protection for code leakage described in Section 5.4 of [@!JARM].
+
+## Confusion between resource servers and clients in introspection request
+
+In [@!RFC9701], the resource server accessing
+the introspection endpoint is seen in the role of a client towards the
+authorization server that is providing the introspection endpoint. A malicious
+client (that is not a resource server) could attempt to call the introspection
+endpoint directly, and thus gather information about an access token to which it
+is not supposed to have access. This may, for example, leak secrets including,
+if the access token was leaked or stolen, personal information about an
+end-user.
+
+The authorization server therefore must ensure that the resource server is not
+confused with a regular client that is not supposed to call the introspection
+endpoint, and that the resource server has the necessary authorization to access
+the information associated with the access token.
+
+## Non-repudiation limited to individual messages
+
+It is important to note that while this specification provides mechanisms for non-repudiation for 
+individual messages, it does not provide non-repudiation guarantees for a sequence of messages.
+
+## Non-repudiation not provided for front channel authorization requests
+
+While only a small amount of information is present in a [@!FAPI2_Security_Profile] front channel 
+authorization request, it is important to note that non-repudiation is not provided for this message. 
+
+## Difficulty in linking a signed message to a real world identity
+
+This specification provides the technical means to sign messages, however proving that a specific signed response is
+linked to a specific real world end-user, or that a real world end-user initiated a specific request is outside of the
+scope of this document.
+
+## The value of JARM for non-repudiation
+
+The values signed in a JARM response may be of limited value for non-repudiation as the values are artifacts 
+of the OAuth flow (e.g. code and state) rather than real world values (e.g. account number and amount). However JARM
+is still useful in providing message integrity to the authorization response.
+
+
+
+# Privacy considerations
+
+In addition to the privacy considerations detailed in [@!FAPI2_Security_Profile] implementers should consider
+the privacy implications of storing messages for the purpose of non-repudiation. 
+
+Such messages may well contain personally identifiable information and implementers should evaluate 
+whether such messages need to be stored. If they are stored then adequate access controls must be 
+put in place to protect that data. Such controls should follow data minimisation principles and ensure that 
+there are tamper-proof audit logs.
+
+# IANA considerations
+## OAuth dynamic client registration metadata registration
+
+This specification requests registration of the following client metadata
+definitions in the IANA "OAuth Dynamic Client Registration Metadata" registry
+established by [@RFC7591]:
+
+### Registry contents
+
+* Client Metadata Name: `response_modes`
+* Client Metadata Description: Array of the response modes that the client may use
+* Change Controller: IESG
+* Specification Document(s): (#client-metadata) of this specification
+
+# Acknowledgements
+
+This specification was developed by the OpenID FAPI Working Group. 
+
+We would like to thank Takahiko Kawasaki, Filip Skokan, Nat Sakimura, Dima Postnikov, Brian Campbell, Ralph Bragg, Justin Richer and Lukasz Jaromin for their valuable feedback and contributions that helped to evolve this specification.
+
+
+{backmatter}
+
+<reference anchor="FAPI2_Security_Profile" target="https://openid.net/specs/fapi-security-profile-2_0.html">
+  <front>
+    <title>FAPI 2.0 Security Profile</title>
+    <author initials="D." surname="Fett" fullname="Daniel Fett">
+      <organization>Authlete</organization>
+    </author>
+    <author initials="D." surname="Tonge" fullname="Dave Tonge">
+      <organization>Moneyhub Financial Technology Ltd.</organization>
+    </author>
+    <author initials="J." surname="Heenan" fullname="Joseph Heenan">
+      <organization>Authlete</organization>
+    </author>
+   <date day="22" month="Feb" year="2025"/>
+  </front>
+</reference>
+
+<reference anchor="attackermodel" target="https://openid.net/specs/fapi-attacker-model-2_0.html">
+  <front>
+    <title>FAPI 2.0 Attacker Model</title>
+    <author initials="D." surname="Fett" fullname="Daniel Fett">
+      <organization>Authlete</organization>
+    </author>
+   <date day="22" month="FEb" year="2025"/>
+  </front>
+</reference>
+
+<reference anchor="OIDC" target="http://openid.net/specs/openid-connect-core-1_0.html">
+  <front>
+    <title>OpenID Connect Core 1.0 incorporating errata set 2</title>
+    <author initials="N." surname="Sakimura" fullname="Nat Sakimura">
+      <organization>NRI</organization>
+    </author>
+    <author initials="J." surname="Bradley" fullname="John Bradley">
+      <organization>Ping Identity</organization>
+    </author>
+    <author initials="M." surname="Jones" fullname="Mike Jones">
+      <organization>Microsoft</organization>
+    </author>
+    <author initials="B." surname="de Medeiros" fullname="Breno de Medeiros">
+      <organization>Google</organization>
+    </author>
+    <author initials="C." surname="Mortimore" fullname="Chuck Mortimore">
+      <organization>Salesforce</organization>
+    </author>
+   <date day="8" month="Nov" year="2014"/>
+  </front>
+</reference>
+
+<reference anchor="JARM" target="https://openid.net/specs/oauth-v2-jarm-final.html">
+  <front>
+    <title>JWT Secured Authorization Response Mode for OAuth 2.0 (JARM)</title>
+    <author initials="T." surname="Lodderstedt" fullname="Torsten Lodderstedt">
+      <organization>Yes</organization>
+    </author>
+    <author initials="B." surname="Campbell" fullname="Brian Campbell">
+      <organization>Ping</organization>
+    </author>
+   <date day="9" month="Nov" year="2022"/>
+  </front>
+</reference>
+
+<reference anchor="FAPI2MSANALYSIS" target="http://dx.doi.org/10.18419/opus-13698">
+  <front>
+    <title>Formal security analysis of the OpenID FAPI 2.0 Security Profile with 
+    FAPI 2.0 Message Signing, FAPI-CIBA, Dynamic Client Registration and Management </title>    
+    <author initials="P." surname="Hosseyni" fullname="Pedram Hosseyni">
+      <organization>University of Stuttgart, Germany</organization>
+    </author>
+    <author initials="R." surname="Kuesters" fullname="Ralf Kuesters">
+      <organization>University of Stuttgart, Germany</organization>
+    </author>
+    <author initials="T." surname="Würtele" fullname="Tim Würtele">
+      <organization>University of Stuttgart, Germany</organization>
+    </author>
+    <date day="04" month="Oct" year="2024"/>
+  </front>  
+</reference>
+
+<reference anchor="NIST.SP.800-133" target="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-133.pdf">
+  <front>
+    <title>NIST Special Publication 800-133</title>
+     <author fullname="Elaine Barker">
+      <organization></organization>
+    </author>
+     <author fullname="Allen Roginsky ">
+      <organization></organization>
+    </author>
+   <date day="23" month="July" year="2019"/>
+  </front>
+</reference>
+
+
+
+<reference anchor="ISODIR2" target="https://www.iso.org/sites/directives/current/part2/index.xhtml">
+<front>
+<title>ISO/IEC Directives, Part 2 - Principles and rules for the structure and drafting of ISO and IEC documents</title>
+    <author fullname="ISO/IEC">
+      <organization>ISO/IEC</organization>
+    </author>
+</front>
+</reference>
+
+
+<reference anchor="ISO29100" target="https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html#:~:text=IEC%2029100%3A2011-,EN,-%2D%20FR">
+<front>
+<title>ISO/IEC 29100 Information technology – Security techniques – Privacy framework</title>
+    <author fullname="ISO/IEC">
+      <organization></organization>
+    </author>
+</front>
+</reference>
+
+# Notices
+
+Copyright (c) 2025 The OpenID Foundation.
+
+The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
+or other interested party a non-exclusive, royalty free, worldwide copyright license to
+reproduce, prepare derivative works from, distribute, perform and display, this
+Implementers Draft, Final Specification, or Final Specification Incorporating Errata
+Corrections solely for the purposes of (i) developing specifications, and (ii)
+implementing Implementers Drafts, Final Specifications, and Final Specification
+Incorporating Errata Corrections based on such documents, provided that attribution
+be made to the OIDF as the source of the material, but that such attribution does not
+indicate an endorsement by the OIDF.
+
+The technology described in this specification was made available from contributions
+from various sources, including members of the OpenID Foundation and others.
+Although the OpenID Foundation has taken steps to help ensure that the technology
+is available for distribution, it takes no position regarding the validity or scope of any
+intellectual property or other rights that might be claimed to pertain to the
+implementation or use of the technology described in this specification or the extent
+to which any license under such rights might or might not be available; neither does it
+represent that it has made any independent effort to identify any such rights. The
+OpenID Foundation and the contributors to this specification make no (and hereby
+expressly disclaim any) warranties (express, implied, or otherwise), including implied
+warranties of merchantability, non-infringement, fitness for a particular purpose, or
+title, related to this specification, and the entire risk as to implementing this
+specification is assumed by the implementer. The OpenID Intellectual Property
+Rights policy (found at openid.net) requires contributors to offer a patent promise not
+to assert certain patent claims against other contributors and against implementers.
+OpenID invites any interested party to bring to its attention any copyrights, patents,
+patent applications, or other proprietary rights that may cover technology that may be
+required to practice this specification.

--- a/fapi/fapi-message-signing-2_0-final.xml
+++ b/fapi/fapi-message-signing-2_0-final.xml
@@ -1,0 +1,479 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- name="GENERATOR" content="github.com/mmarkdown/mmark Mmark Markdown Processor - mmark.miek.nl" -->
+<rfc version="3" ipr="none" docName="fapi-message-signing-2_0-02" submissionType="IETF" category="std" xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude" indexInclude="true" consensus="true">
+
+<front>
+<title abbrev="fapi-message-signing-2">FAPI 2.0 Message Signing</title><seriesInfo value="fapi-message-signing-2_0-02" status="standard" name="Internet-Draft"></seriesInfo>
+<author initials="D." surname="Tonge" fullname="Dave Tonge"><organization>Moneyhub Financial Technology</organization><address><postal><street></street>
+</postal><email>dave@tonge.org</email>
+</address></author><author initials="D." surname="Fett" fullname="Daniel Fett"><organization>Authlete</organization><address><postal><street></street>
+</postal><email>mail@danielfett.de</email>
+</address></author><author initials="J." surname="Heenan" fullname="Joseph Heenan"><organization>Authlete</organization><address><postal><street></street>
+</postal><email>joseph@authlete.com</email>
+</address></author><date/>
+<area>Internet</area>
+<workgroup>fapi</workgroup>
+<keyword>security</keyword>
+<keyword>openid</keyword>
+
+<abstract>
+<t>OIDF FAPI 2.0 Message Signing is an API security profile for signing and verifying certain FAPI 2.0 Security Profile <xref target="FAPI2_Security_Profile"></xref> based requests and responses.</t>
+</abstract>
+
+<note><name>Foreword</name>
+<t>The OpenID Foundation (OIDF) promotes, protects and nurtures the OpenID community and technologies. As a non-profit international standardizing body, it is comprised by over 160 participating entities (workgroup participant). The work of preparing implementer drafts and final international standards is carried out through OIDF workgroups in accordance with the OpenID Process. Participants interested in a subject for which a workgroup has been established have the right to be represented in that workgroup. International organizations, governmental and non-governmental, in liaison with OIDF, also take part in the work. OIDF collaborates closely with other standardizing bodies in the related fields.</t>
+<t>Final drafts adopted by the Workgroup through consensus are circulated publicly for the public review for 60 days and for the OIDF members for voting. Publication as an OIDF Standard requires approval by at least 50% of the members casting a vote. There is a possibility that some of the elements of this document may be the subject to patent rights. OIDF shall not be held responsible for identifying any or all such patent rights.</t>
+</note>
+
+<note><name>Introduction</name>
+<t>OIDF FAPI 2.0 is an API security profile based on the OAuth 2.0 Authorization
+Framework <xref target="RFC6749"></xref>. This Message Signing Profile is part of the FAPI 2.0 family of specifications with a focus on providing interoperable support for non-repudiation across OAuth 2.0 based requests and responses.</t>
+<t>It has been formally analysed <xref target="FAPI2MSANALYSIS"></xref> for it's security and non-repudiation properties.</t>
+</note>
+
+<note><name>Warning</name>
+<t>This document is not an OIDF International Standard. It is distributed for
+review and comment. It is subject to change without notice and may not be
+referred to as an International Standard.</t>
+<t>Recipients of this draft are invited to submit, with their comments,
+notification of any relevant patent rights of which they are aware and to
+provide supporting documentation.</t>
+</note>
+
+<note><name>Notational conventions</name>
+<t>The keywords &quot;shall&quot;, &quot;shall not&quot;, &quot;should&quot;, &quot;should not&quot;, &quot;may&quot;, and &quot;can&quot; in
+this document are to be interpreted as described in ISO Directive Part 2
+<xref target="ISODIR2"></xref>. These keywords are not used as dictionary terms such that any
+occurrence of them shall be interpreted as keywords and are not to be
+interpreted with their natural language meanings.</t>
+</note>
+
+</front>
+
+<middle>
+
+<section anchor="scope"><name>Scope</name>
+<t>This document specifies the methods for clients, authorization servers and resource servers to sign and verify messages.</t>
+</section>
+
+<section anchor="normative-references"><name>Normative references</name>
+<t>The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.</t>
+<t>See Clause 8 for normative references.</t>
+</section>
+
+<section anchor="terms-and-definitions"><name>Terms and definitions</name>
+<t>For the purpose of this document, the terms defined in <xref target="RFC6749"></xref>, <xref target="RFC6750"></xref>, <xref target="RFC7636"></xref>, <xref target="OIDC"></xref> and <xref target="ISO29100"></xref> apply.</t>
+</section>
+
+<section anchor="symbols-and-abbreviated-terms"><name>Symbols and Abbreviated terms</name>
+<t><strong>API</strong> – Application Programming Interface</t>
+<t><strong>HTTP</strong> – Hyper Text Transfer Protocol</t>
+<t><strong>JAR</strong> – JWT-Secured Authorization Request</t>
+<t><strong>JARM</strong> – JWT Secured Authorization Response Mode</t>
+<t><strong>JWT</strong> – JSON Web Token</t>
+<t><strong>JSON</strong> – JavaScript Object Notation</t>
+<t><strong>OIDF</strong> – OpenID Foundation</t>
+<t><strong>PAR</strong> – Pushed Authorization Requests</t>
+<t><strong>PKCE</strong> – Proof Key for Code Exchange</t>
+<t><strong>REST</strong> – Representational State Transfer</t>
+<t><strong>TLS</strong> – Transport Layer Security</t>
+<t><strong>URI</strong> – Uniform Resource Identifier</t>
+<t><strong>URL</strong> – Uniform Resource Locator</t>
+</section>
+
+<section anchor="message-signing-profile"><name>Message signing profile</name>
+<t>OIDF FAPI 2.0 is an API security profile based on the OAuth 2.0 Authorization
+Framework <xref target="RFC6749"></xref>. This Message Signing Profile aims to reach the security goals
+laid out in the Attacker Model <xref target="attackermodel"></xref> plus the non-repudiation goals listed below.</t>
+<t>All provisions of the <xref target="FAPI2_Security_Profile"></xref> apply to the Message Signing Profile
+as well, with the extensions described in the following.</t>
+
+<section anchor="profile"><name>Profile</name>
+<t>In addition to the technologies used in the <xref target="FAPI2_Security_Profile"></xref>, the
+following standards are used in this profile:</t>
+
+<ul spacing="compact">
+<li>OAuth 2.0 JWT Secured Authorization Request (JAR) <xref target="RFC9101"></xref> for signing authorization requests</li>
+<li>JWT Secured Authorization Response Mode for OAuth 2.0 <xref target="JARM"></xref> for signing authorization responses</li>
+<li>OAuth 2.0 Token Introspection <xref target="RFC7662"></xref> with <xref target="RFC9701"></xref> for signing introspection responses</li>
+</ul>
+<t>We understand that some ecosystems may only desire to implement 1, 2 or 3 of the above, it is therefore
+anticipated that a piece of software will be able to conform to each of the methods separately, i.e. there
+will be separate conformance testing options for each of the following:</t>
+
+<ul spacing="compact">
+<li>Signed authorization requests</li>
+<li>Signed authorization responses</li>
+<li>Signed introspection responses</li>
+</ul>
+</section>
+
+<section anchor="non-repudiation"><name>Non-repudiation</name>
+<t>Beyond what is captured by the security goals and the attacker model in
+<xref target="attackermodel"></xref>, parties could try to deny having sent a particular message,
+for example, a payment request. For this purpose, non-repudiation is needed.</t>
+<t>In the context of this specification, non-repudiation refers to the assurance that the owner of
+a signature key pair that was capable of generating an existing signature corresponding to certain
+data cannot convincingly deny having signed the data (<xref target="NIST.SP.800-133"></xref>).</t>
+<t>This is usually achieved by providing application-level signatures that can be
+stored together with the payload and meaningful metadata of a request or
+response.</t>
+<t>The following messages are affected by this specification:</t>
+
+<ul spacing="compact">
+<li>NR1: pushed authorization requests</li>
+<li>NR2: authorization requests (front-channel)</li>
+<li>NR3: authorization responses (front-channel)<br />
+</li>
+<li>NR4: introspection responses<br />
+</li>
+<li>NR5: ID tokens</li>
+</ul>
+</section>
+
+<section anchor="signing-authorization-requests"><name>Signing authorization requests</name>
+<t>To support non-repudiation for NR1, pushed authorization requests can be signed.
+Because FAPI2 uses <xref target="RFC9126"></xref>, NR2 is achieved by default when the pushed authorization request
+is signed.</t>
+
+<section anchor="requirements-for-authorization-servers"><name>Requirements for authorization servers</name>
+<t>Authorization servers implementing FAPI2 authorization request signing</t>
+
+<ol spacing="compact">
+<li>shall support, require use of, and verify signed request objects according to JAR
+<xref target="RFC9101"></xref> at the PAR endpoint <xref target="RFC9126"></xref>;</li>
+<li>shall require the aud claim in the request object to be, or to be an array containing, the authorization server's issuer identifier URL;</li>
+<li>shall require the request object to contain an <tt>nbf</tt> claim that is no longer than 60 minutes in the past; and</li>
+<li>shall require the request object to contain an <tt>exp</tt> claim that has a lifetime of no longer than 60 minutes after the <tt>nbf</tt> claim;</li>
+<li>shall accept request objects with <tt>typ</tt> header parameter with a value <tt>oauth-authz-req+jwt</tt>.</li>
+</ol>
+</section>
+
+<section anchor="requirements-for-clients"><name>Requirements for clients</name>
+<t>Clients implementing FAPI2 authorization request signing</t>
+
+<ol spacing="compact">
+<li>shall send all authorization parameters to the PAR endpoint <xref target="RFC9126"></xref> in a JAR
+<xref target="RFC9101"></xref> signed requested object;</li>
+<li>shall send the <tt>aud</tt> claim in the request object as the authorization server's issuer identifier URL;</li>
+<li>shall send a <tt>nbf</tt> claim in the request object;</li>
+<li>shall send an <tt>exp</tt> claim in the request object that has a lifetime of no longer than 60 minutes;</li>
+<li>should send a <tt>typ</tt> header parameter with a value <tt>oauth-authz-req+jwt</tt>.</li>
+</ol>
+</section>
+
+<section anchor="client-metadata"><name>Client metadata</name>
+<t>The Dynamic Client Registration Protocol <xref target="RFC7591"></xref> defines an API
+for dynamically registering OAuth 2.0 client metadata with authorization servers.
+The metadata defined by <xref target="RFC7591"></xref>, and registered extensions to it,
+also imply a general data model for clients that is useful for authorization server implementations
+even when the dynamic client registration protocol isn't in play.
+Such implementations will typically have some sort of user interface available for managing client configuration.</t>
+<t>The following client metadata parameter is introduced by this specification:</t>
+
+<ul spacing="compact">
+<li><t><tt>response_modes</tt>:</t>
+
+<ul spacing="compact">
+<li>OPTIONAL. A JSON array of strings containing the list of response modes that
+the client may use. If omitted, the default is that the client may use any of
+the response modes supported by the authorization server.</li>
+</ul></li>
+</ul>
+</section>
+</section>
+
+<section anchor="signing-authorization-responses"><name>Signing authorization responses</name>
+<t>To support non-repudiation for NR3, authorization responses can be signed.</t>
+
+<section anchor="requirements-for-authorization-servers-1"><name>Requirements for authorization servers</name>
+<t>Authorization servers implementing FAPI2 authorization response signing</t>
+
+<ol spacing="compact">
+<li>shall support, require use of, and issue signed authorization responses via JWT Secured Authorization
+Response Mode for OAuth 2.0 <xref target="JARM"></xref>.</li>
+</ol>
+<t><strong>NOTE</strong>: When using <xref target="JARM"></xref> an authorization server should only include the iss authorization response
+parameter defined by <xref target="RFC9207"></xref> inside the JWT. This is because <xref target="RFC9207"></xref> defines <tt>iss</tt>
+to be an authorization response parameter, and <xref target="JARM"></xref> Section 4.1 requires all authorization
+response parameters to be inside the JWT.</t>
+</section>
+
+<section anchor="requirements-for-clients-1"><name>Requirements for clients</name>
+<t>Clients implementing FAPI2 authorization response signing</t>
+
+<ol spacing="compact">
+<li>shall set the <tt>response_mode</tt> to <tt>jwt</tt> in the authorization request as defined in <xref target="JARM"></xref>; and</li>
+<li>shall verify signed authorization responses according to <xref target="JARM"></xref>.</li>
+</ol>
+</section>
+</section>
+
+<section anchor="signing-introspection-responses"><name>Signing introspection responses</name>
+<t>To support non-repudiation for NR4, introspection responses can be signed.</t>
+
+<section anchor="requirements-for-authorization-servers-2"><name>Requirements for authorization servers</name>
+<t>Authorization servers implementing FAPI2 introspection response signing</t>
+
+<ol spacing="compact">
+<li>shall sign introspection responses that are issued in JWT format according to <xref target="RFC9701"></xref></li>
+</ol>
+</section>
+
+<section anchor="requirements-for-clients-2"><name>Requirements for clients</name>
+<t>Clients implementing FAPI2 introspection response signing</t>
+
+<ol spacing="compact">
+<li>shall request signed token introspection responses according to <xref target="RFC9701"></xref>; and</li>
+<li>shall verify the signed token introspection responses.</li>
+</ol>
+</section>
+</section>
+
+<section anchor="signing-id-tokens"><name>Signing ID tokens</name>
+<t>To support non-repudiation for NR5, signed ID tokens are used.</t>
+
+<section anchor="requirements-for-authorization-servers-3"><name>Requirements for authorization servers</name>
+<t>No additional requirements.</t>
+<t>Note: Authorization servers implementing FAPI2 are already required to sign ID tokens as specified in section 5.4.1 in the <xref target="FAPI2_Security_Profile"></xref>.</t>
+</section>
+
+<section anchor="requirements-for-clients-3"><name>Requirements for clients</name>
+<t>Clients requesting and receiving ID tokens</t>
+
+<ol spacing="compact">
+<li>shall verify the signature of the signed ID token received.</li>
+</ol>
+</section>
+</section>
+</section>
+
+<section anchor="security-considerations"><name>Security considerations</name>
+
+<section anchor="authorization-response-encryption"><name>Authorization response encryption</name>
+<t>In FAPI2, there is no confidential information in the authorization response, hence encryption of the authorization response is not required for the purposes of security or confidentiality. In addition, to achieve greater interoperability, it is not recommended to use encryption in this case.</t>
+<t>Usage of PKCE in FAPI 2 provides protection for code leakage described in Section 5.4 of <xref target="JARM"></xref>.</t>
+</section>
+
+<section anchor="confusion-between-resource-servers-and-clients-in-introspection-request"><name>Confusion between resource servers and clients in introspection request</name>
+<t>In <xref target="RFC9701"></xref>, the resource server accessing
+the introspection endpoint is seen in the role of a client towards the
+authorization server that is providing the introspection endpoint. A malicious
+client (that is not a resource server) could attempt to call the introspection
+endpoint directly, and thus gather information about an access token to which it
+is not supposed to have access. This may, for example, leak secrets including,
+if the access token was leaked or stolen, personal information about an
+end-user.</t>
+<t>The authorization server therefore must ensure that the resource server is not
+confused with a regular client that is not supposed to call the introspection
+endpoint, and that the resource server has the necessary authorization to access
+the information associated with the access token.</t>
+</section>
+
+<section anchor="non-repudiation-limited-to-individual-messages"><name>Non-repudiation limited to individual messages</name>
+<t>It is important to note that while this specification provides mechanisms for non-repudiation for
+individual messages, it does not provide non-repudiation guarantees for a sequence of messages.</t>
+</section>
+
+<section anchor="non-repudiation-not-provided-for-front-channel-authorization-requests"><name>Non-repudiation not provided for front channel authorization requests</name>
+<t>While only a small amount of information is present in a <xref target="FAPI2_Security_Profile"></xref> front channel
+authorization request, it is important to note that non-repudiation is not provided for this message.</t>
+</section>
+
+<section anchor="difficulty-in-linking-a-signed-message-to-a-real-world-identity"><name>Difficulty in linking a signed message to a real world identity</name>
+<t>This specification provides the technical means to sign messages, however proving that a specific signed response is
+linked to a specific real world end-user, or that a real world end-user initiated a specific request is outside of the
+scope of this document.</t>
+</section>
+
+<section anchor="the-value-of-jarm-for-non-repudiation"><name>The value of JARM for non-repudiation</name>
+<t>The values signed in a JARM response may be of limited value for non-repudiation as the values are artifacts
+of the OAuth flow (e.g. code and state) rather than real world values (e.g. account number and amount). However JARM
+is still useful in providing message integrity to the authorization response.</t>
+</section>
+</section>
+
+<section anchor="privacy-considerations"><name>Privacy considerations</name>
+<t>In addition to the privacy considerations detailed in <xref target="FAPI2_Security_Profile"></xref> implementers should consider
+the privacy implications of storing messages for the purpose of non-repudiation.</t>
+<t>Such messages may well contain personally identifiable information and implementers should evaluate
+whether such messages need to be stored. If they are stored then adequate access controls must be
+put in place to protect that data. Such controls should follow data minimisation principles and ensure that
+there are tamper-proof audit logs.</t>
+</section>
+
+<section anchor="iana-considerations"><name>IANA considerations</name>
+
+<section anchor="oauth-dynamic-client-registration-metadata-registration"><name>OAuth dynamic client registration metadata registration</name>
+<t>This specification requests registration of the following client metadata
+definitions in the IANA &quot;OAuth Dynamic Client Registration Metadata&quot; registry
+established by <xref target="RFC7591"></xref>:</t>
+
+<section anchor="registry-contents"><name>Registry contents</name>
+
+<ul spacing="compact">
+<li>Client Metadata Name: <tt>response_modes</tt></li>
+<li>Client Metadata Description: Array of the response modes that the client may use</li>
+<li>Change Controller: IESG</li>
+<li>Specification Document(s): <xref target="client-metadata"></xref> of this specification</li>
+</ul>
+</section>
+</section>
+</section>
+
+<section anchor="acknowledgements"><name>Acknowledgements</name>
+<t>This specification was developed by the OpenID FAPI Working Group.</t>
+<t>We would like to thank Takahiko Kawasaki, Filip Skokan, Nat Sakimura, Dima Postnikov, Brian Campbell, Ralph Bragg, Justin Richer and Lukasz Jaromin for their valuable feedback and contributions that helped to evolve this specification.</t>
+</section>
+
+</middle>
+
+<back>
+<references><name>Normative References</name>
+<reference anchor="FAPI2_Security_Profile" target="https://openid.net/specs/fapi-security-profile-2_0.html">
+  <front>
+    <title>FAPI 2.0 Security Profile</title>
+    <author fullname="Daniel Fett" initials="D." surname="Fett">
+      <organization>Authlete</organization>
+    </author>
+    <author fullname="Dave Tonge" initials="D." surname="Tonge">
+      <organization>Moneyhub Financial Technology Ltd.</organization>
+    </author>
+    <author fullname="Joseph Heenan" initials="J." surname="Heenan">
+      <organization>Authlete</organization>
+    </author>
+    <date year="2025" month="Feb" day="22"></date>
+  </front>
+</reference>
+<reference anchor="ISO29100" target="https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html#:~:text=IEC%2029100%3A2011-,EN,-%2D%20FR">
+  <front>
+    <title>ISO/IEC 29100 Information technology – Security techniques – Privacy framework</title>
+    <author fullname="ISO/IEC">
+      <organization></organization>
+    </author>
+  </front>
+</reference>
+<reference anchor="JARM" target="https://openid.net/specs/oauth-v2-jarm-final.html">
+  <front>
+    <title>JWT Secured Authorization Response Mode for OAuth 2.0 (JARM)</title>
+    <author fullname="Torsten Lodderstedt" initials="T." surname="Lodderstedt">
+      <organization>Yes</organization>
+    </author>
+    <author fullname="Brian Campbell" initials="B." surname="Campbell">
+      <organization>Ping</organization>
+    </author>
+    <date year="2022" month="Nov" day="9"></date>
+  </front>
+</reference>
+<reference anchor="NIST.SP.800-133" target="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-133.pdf">
+  <front>
+    <title>NIST Special Publication 800-133</title>
+    <author fullname="Elaine Barker">
+      <organization></organization>
+    </author>
+    <author fullname="Allen Roginsky ">
+      <organization></organization>
+    </author>
+    <date year="2019" month="July" day="23"></date>
+  </front>
+</reference>
+<reference anchor="OIDC" target="http://openid.net/specs/openid-connect-core-1_0.html">
+  <front>
+    <title>OpenID Connect Core 1.0 incorporating errata set 2</title>
+    <author fullname="Nat Sakimura" initials="N." surname="Sakimura">
+      <organization>NRI</organization>
+    </author>
+    <author fullname="John Bradley" initials="J." surname="Bradley">
+      <organization>Ping Identity</organization>
+    </author>
+    <author fullname="Mike Jones" initials="M." surname="Jones">
+      <organization>Microsoft</organization>
+    </author>
+    <author fullname="Breno de Medeiros" initials="B." surname="de Medeiros">
+      <organization>Google</organization>
+    </author>
+    <author fullname="Chuck Mortimore" initials="C." surname="Mortimore">
+      <organization>Salesforce</organization>
+    </author>
+    <date year="2014" month="Nov" day="8"></date>
+  </front>
+</reference>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.6749.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.6750.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7636.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7662.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9101.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9126.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9207.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9701.xml"/>
+<reference anchor="attackermodel" target="https://openid.net/specs/fapi-attacker-model-2_0.html">
+  <front>
+    <title>FAPI 2.0 Attacker Model</title>
+    <author fullname="Daniel Fett" initials="D." surname="Fett">
+      <organization>Authlete</organization>
+    </author>
+    <date year="2025" month="FEb" day="22"></date>
+  </front>
+</reference>
+</references>
+<references><name>Informative References</name>
+<reference anchor="FAPI2MSANALYSIS" target="http://dx.doi.org/10.18419/opus-13698">
+  <front>
+    <title>Formal security analysis of the OpenID FAPI 2.0 Security Profile with &#xA;    FAPI 2.0 Message Signing, FAPI-CIBA, Dynamic Client Registration and Management </title>
+    <author fullname="Pedram Hosseyni" initials="P." surname="Hosseyni">
+      <organization>University of Stuttgart, Germany</organization>
+    </author>
+    <author fullname="Ralf Kuesters" initials="R." surname="Kuesters">
+      <organization>University of Stuttgart, Germany</organization>
+    </author>
+    <author fullname="Tim Würtele" initials="T." surname="Würtele">
+      <organization>University of Stuttgart, Germany</organization>
+    </author>
+    <date year="2024" month="Oct" day="04"></date>
+  </front>
+</reference>
+<reference anchor="ISODIR2" target="https://www.iso.org/sites/directives/current/part2/index.xhtml">
+  <front>
+    <title>ISO/IEC Directives, Part 2 - Principles and rules for the structure and drafting of ISO and IEC documents</title>
+    <author fullname="ISO/IEC">
+      <organization>ISO/IEC</organization>
+    </author>
+  </front>
+</reference>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7591.xml"/>
+</references>
+
+<section anchor="notices"><name>Notices</name>
+<t>Copyright (c) 2025 The OpenID Foundation.</t>
+<t>The OpenID Foundation (OIDF) grants to any Contributor, developer, implementer,
+or other interested party a non-exclusive, royalty free, worldwide copyright license to
+reproduce, prepare derivative works from, distribute, perform and display, this
+Implementers Draft, Final Specification, or Final Specification Incorporating Errata
+Corrections solely for the purposes of (i) developing specifications, and (ii)
+implementing Implementers Drafts, Final Specifications, and Final Specification
+Incorporating Errata Corrections based on such documents, provided that attribution
+be made to the OIDF as the source of the material, but that such attribution does not
+indicate an endorsement by the OIDF.</t>
+<t>The technology described in this specification was made available from contributions
+from various sources, including members of the OpenID Foundation and others.
+Although the OpenID Foundation has taken steps to help ensure that the technology
+is available for distribution, it takes no position regarding the validity or scope of any
+intellectual property or other rights that might be claimed to pertain to the
+implementation or use of the technology described in this specification or the extent
+to which any license under such rights might or might not be available; neither does it
+represent that it has made any independent effort to identify any such rights. The
+OpenID Foundation and the contributors to this specification make no (and hereby
+expressly disclaim any) warranties (express, implied, or otherwise), including implied
+warranties of merchantability, non-infringement, fitness for a particular purpose, or
+title, related to this specification, and the entire risk as to implementing this
+specification is assumed by the implementer. The OpenID Intellectual Property
+Rights policy (found at openid.net) requires contributors to offer a patent promise not
+to assert certain patent claims against other contributors and against implementers.
+OpenID invites any interested party to bring to its attention any copyrights, patents,
+patent applications, or other proprietary rights that may cover technology that may be
+required to practice this specification.</t>
+</section>
+
+</back>
+
+</rfc>


### PR DESCRIPTION
This was generated from the latest fapi repo by:

1. Removing the document history from the .md
2. docker run -v `pwd`:/data danielfett/markdown2rfc fapi-2_0-message-signing.md
3. Renaming the xml/html to remove the draft number
4. Rename md to match the other files
5. Editting HTML to add 'Status: Final' in the header