### PR TITLE
chore: bump GitHub Actions to Node-24-compatible majors

### DIFF
--- a/.github/workflows/oidf-publish-prep.yml
+++ b/.github/workflows/oidf-publish-prep.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Check if already previewed
         id: already_previewed
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const headSha = context.payload.pull_request.head.sha.substring(0, 7);
@@ -125,7 +125,7 @@ jobs:
       - name: Check approval permissions
         if: steps.already_previewed.outputs.skip != 'true'
         id: approval_check
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -208,7 +208,7 @@ jobs:
 
       - name: Comment on PR
         if: always() && steps.already_previewed.outputs.skip != 'true' && steps.approval_check.outcome != 'failure'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/oidf-publish.yml
+++ b/.github/workflows/oidf-publish.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Comment on merged PR
         if: always() && steps.changes.outputs.has_wg_changes == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -182,7 +182,7 @@ jobs:
 
       - name: Open issue on failure
         if: failure()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.create({

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Comment with preview links
         if: steps.files.outputs.has_html == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const prNum = context.issue.number;

--- a/.github/workflows/publication-checks.yml
+++ b/.github/workflows/publication-checks.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Check branch naming
         if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'propose/')
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({
@@ -141,7 +141,7 @@ jobs:
 
       - name: Comment on PR
         if: always() && steps.checks.outcome != '' && steps.checks.outcome != 'skipped' && github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
GitHub forces JS actions to Node 24 on 2026-06-16 and removes Node 20 on 2026-09-16. This bumps actions pinned to Node-20 majors up to their latest Node-24-compatible majors.

## Bumps
- actions/github-script v8 -> v9 (8 occurrences: oidf-publish-prep.yml, oidf-publish.yml, preview.yml, publication-checks.yml)

## Already current (left as-is)
- actions/checkout @v6 (latest)
- actions/setup-python @v6 (latest)
- appleboy/ssh-action @v1.2.5 (third-party, composite action, latest major v1)

No breaking-change concerns: github-script v8 -> v9 is a runtime/Node bump for these inline scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
