### PR TITLE
Handle PRs opened from forks

### DIFF
--- a/.github/workflows/fork-pr-guard.yml
+++ b/.github/workflows/fork-pr-guard.yml
@@ -1,0 +1,57 @@
+name: Fork PR Guard
+# Explains the publication process on PRs opened from forks, which the
+# publication automation cannot support (fork PRs get a read-only token,
+# so checks/preview cannot post results, and the approval flow breaks).
+#
+# SECURITY: this workflow runs on pull_request_target and therefore has a
+# write token. It must NEVER check out or execute anything from the PR —
+# it may only read event metadata and post a comment.
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    branches:
+      - main
+
+jobs:
+  comment:
+    name: Comment on PRs opened from forks
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post explanation comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- fork-pr-guard -->';
+            const body = `${marker}
+            👋 Thanks for your submission!
+
+            ⚠️ **This PR was opened from a fork**, which this repository's publication automation cannot support: the publication checks and spec preview cannot post their results on fork PRs, and the approval workflow will not run correctly.
+
+            To publish a specification, the changes need to be pushed to a branch in \`openid/publication\` itself:
+
+            1. Someone with write access (a working group editor or the OIDF secretary) pushes these files to a branch named \`propose/{wg-name}/...\` in this repository (for example \`propose/sharedsignals/my-spec\`).
+            2. They open a PR from that branch, and the normal checks, preview, and approval flow will run.
+
+            If you don't have write access, please ask your working group's editors or the OIDF secretary to do this for you.
+
+            See the [publication process documentation](https://openid.net/wg/resources/publishing-specifications/) for details. This PR can stay open for reference, but the publication workflows won't run correctly on it.`;
+
+            // Skip if we already commented (e.g. PR was reopened)
+            for await (const response of github.paginate.iterator(
+              github.rest.issues.listComments,
+              { owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, per_page: 100 }
+            )) {
+              if (response.data.some(c => c.body.includes(marker))) {
+                return;
+              }
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body,
+            });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,7 +14,8 @@ jobs:
     name: Deploy spec preview
     if: >
       github.event.action != 'closed' &&
-      startsWith(github.head_ref, 'propose/')
+      startsWith(github.head_ref, 'propose/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -115,7 +116,8 @@ jobs:
     name: Clean up spec preview
     if: >
       github.event.action == 'closed' &&
-      startsWith(github.head_ref, 'propose/')
+      startsWith(github.head_ref, 'propose/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publication-checks.yml
+++ b/.github/workflows/publication-checks.yml
@@ -17,7 +17,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Check branch naming
-        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'propose/')
+        if: >
+          github.event_name == 'pull_request' &&
+          !startsWith(github.head_ref, 'propose/') &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v8
         with:
           script: |
@@ -139,8 +142,15 @@ jobs:
           echo "" >> "$SUMMARY"
           echo "See the [full log](PLACEHOLDER_JOB_URL) for more detailed diagnostics." >> "$SUMMARY"
 
+          # Also show the summary on the workflow run page; fork PRs get no
+          # comment (read-only token), so this is the only place they see it
+          cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Comment on PR
-        if: always() && steps.checks.outcome != '' && steps.checks.outcome != 'skipped' && github.event_name == 'pull_request'
+        if: >
+          always() && steps.checks.outcome != '' && steps.checks.outcome != 'skipped' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v8
         with:
           script: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Hosts OpenID Foundation specifications for publication to https://openid.net/spe
 - `oidf-publish-prep.yml` - Triggered on PR approval. Runs `publish.py` to preview what files will be published, checks approval permissions, and posts a comment with file list and published URLs. Blocks non-secretary approval of Final/Errata/Implementers specs.
 - `oidf-publish.yml` - Triggered on push to main when WG directories or sync/specs change. Runs `publish.py` to generate correctly-named files in `sync/specs/`, deploys to the web server via SSH, purges CDN cache. Comments on the merged PR with success/failure status and published URLs. Opens a GitHub issue on failure.
 - `sync.yml` - Manual trigger to sync web server with repo.
+- `fork-pr-guard.yml` - Triggered via `pull_request_target` on PRs opened/reopened from forks. Posts a comment explaining that fork PRs are unsupported and pointing to the in-repo `propose/` branch process. Runs with a write token; must never check out or execute PR code.
 
 ## Publication Flow
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenID Foundation proposed publications automation repository
 
-Files proposed by Working Group draft editors should be added into the corresponding sub-directory via a branch that follows the pattern `propose/**`.
+Files proposed by Working Group draft editors should be added into the corresponding sub-directory via a branch **in this repository** that follows the pattern `propose/**`. Pull requests from forks are not supported — the publication automation (checks, previews, and the approval flow) cannot run on them.
 
 Working Group co-chairs or editors will have access rights granted that allow them to commit only to sub-directories that are pertinent to their Working Group(s).
 
@@ -8,7 +8,7 @@ The proposed document sets should be as described in https://openid.net/wg/resou
 
 ## How to publish a specification
 
-1. Create a branch following the `propose/{wg-name}` pattern
+1. Create a branch in this repository (not a fork) following the `propose/{wg-name}` pattern — if you don't have write access, ask your working group's editors or the OIDF secretary to push the files for you
 2. Add your HTML, source (.md or .xml), and .zip files to the appropriate WG sub-directory
 3. Create a Pull Request from your branch to `main`
 4. The automated checks will run and post a comment on the PR showing any issues


### PR DESCRIPTION
Fork PRs get a read-only GITHUB_TOKEN, so the existing workflows failed confusingly (comment steps 403'd, preview checkout couldn't find the branch), as seen on PR #200.

- Add fork-pr-guard.yml: posts an explanatory comment on fork PRs via pull_request_target (metadata-only; never checks out PR code)
- publication-checks.yml: only attempt PR comments on same-repo PRs; also write the results summary to the step summary so it is visible on the run page even when no comment is possible
- preview.yml: skip both jobs for fork PRs (deploy and cleanup need write access to gh-pages that fork PRs never have)
- README.md: state explicitly that propose/ branches must be pushed to this repository and that fork PRs are unsupported
- CLAUDE.md: document the new workflow